### PR TITLE
Add GitHub Actions CI and WASM build workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Lint, build, and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Astro type check
+        run: npm run check
+
+      - name: Production build
+        run: npm run build
+
+      - name: Scan for committed secrets
+        run: bash scripts/check-no-secrets.sh
+
+      - name: Mod metadata coverage (warning only)
+        continue-on-error: true
+        run: python3 scripts/check-mod-metadata.py --priority
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright tests (preview server)
+        run: npm test
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,79 @@
+name: WASM Build
+
+on:
+  pull_request:
+    paths:
+      - 'src/wasm/**'
+      - '.github/workflows/wasm.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    branches: [main]
+    paths:
+      - 'src/wasm/**'
+      - '.github/workflows/wasm.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  schedule:
+    # Nightly at 06:00 UTC
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: wasm-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-wasm:
+    name: Build WASM and run engine tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version-file: src/wasm/cpp/.emscripten-version
+          cache: true
+
+      - name: Build WASM (release)
+        run: npm run wasm:build
+
+      - name: Production build
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: WASM Playwright tests (preview server)
+        run: npx playwright test tests/wasm-assets.spec.ts tests/wasm-engine.spec.ts
+        env:
+          CI: true
+          WASM_BUILT: '1'
+
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-build-${{ github.run_number }}
+          path: public/wasm/
+          retention-days: 14
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Built with [Astro](https://astro.build).
 - [Archive Indexers](#archive-indexers)
 - [WebAssembly Audio Module](#webassembly-audio-module)
 - [Deployment](#deployment)
+- [Continuous Integration](#continuous-integration)
 - [Code Style & Standards](#code-style--standards)
 - [License](#license)
 
@@ -228,6 +229,31 @@ command line; prefer key-based auth and pass secrets from your environment
 
 If any credential was ever committed to git history, **rotate it** — removing it
 from the working tree does not remove it from history.
+
+---
+
+## Continuous Integration
+
+GitHub Actions runs on every pull request and push to `main`. **No repository
+secrets are required** for public CI — deploy credentials are only needed locally
+for `deploy.py` and SFTP upload scripts.
+
+| Workflow | Triggers | What it checks |
+|----------|----------|----------------|
+| [`ci.yml`](.github/workflows/ci.yml) | PR / `main` | `npm ci`, `astro check`, production build, secrets scan, Playwright against the preview server |
+| [`wasm.yml`](.github/workflows/wasm.yml) | PRs touching `src/wasm/**`, nightly cron | Pinned Emscripten build, WASM Playwright tests, artifact upload |
+
+Locally you can mirror the main CI pipeline:
+
+```bash
+npm ci
+npm run ci          # check + build + playwright (dev server locally)
+bash scripts/check-no-secrets.sh
+python3 scripts/check-mod-metadata.py --priority   # optional warning
+```
+
+WASM builds require Emscripten on your machine (`npm run wasm:build`). See
+[`src/wasm/README.md`](src/wasm/README.md) for setup.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "wasm:build": "bash src/wasm/cpp/build.sh release",
+    "check": "astro check",
+    "wasm:build": "bash src/wasm/cpp/build.sh",
     "wasm:build:debug": "bash src/wasm/cpp/build.sh debug",
     "wasm:test": "cd src/wasm/cpp && make test",
     "test": "playwright test",
+    "ci": "npm run check && npm run build && npm test",
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",
     "test:responsive": "playwright test tests/responsive.spec.ts"
@@ -29,6 +31,6 @@
     "typescript": "^5.9.3"
   },
   "engines": {
-    "node": "latest"
+    "node": ">=18.17.1 <23"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,42 +1,57 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const isCI = !!process.env.CI;
+const wasmBuilt = !!process.env.WASM_BUILT;
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: isCI ? [['github'], ['html', { open: 'never' }]] : 'html',
   use: {
     baseURL: 'http://localhost:4321',
     trace: 'on-first-retry',
   },
 
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-    {
-      name: 'mobile-chrome',
-      use: { ...devices['Pixel 5'] },
-    },
-    {
-      name: 'mobile-safari',
-      use: { ...devices['iPhone 12'] },
-    },
-    {
-      name: 'tablet',
-      use: { 
-        ...devices['iPad Pro'],
-      },
-    },
-  ],
+  testIgnore:
+    isCI && !wasmBuilt
+      ? ['tests/wasm-assets.spec.ts', 'tests/wasm-engine.spec.ts']
+      : [],
+
+  projects: isCI
+    ? [
+        {
+          name: 'chromium',
+          use: { ...devices['Desktop Chrome'] },
+        },
+      ]
+    : [
+        {
+          name: 'chromium',
+          use: { ...devices['Desktop Chrome'] },
+        },
+        {
+          name: 'mobile-chrome',
+          use: { ...devices['Pixel 5'] },
+        },
+        {
+          name: 'mobile-safari',
+          use: { ...devices['iPhone 12'] },
+        },
+        {
+          name: 'tablet',
+          use: {
+            ...devices['iPad Pro'],
+          },
+        },
+      ],
 
   webServer: {
-    command: 'npm run dev',
+    command: isCI ? 'npm run preview' : 'npm run dev',
     url: 'http://localhost:4321/rb338/',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
     timeout: 120 * 1000,
   },
 });

--- a/scripts/check-no-secrets.sh
+++ b/scripts/check-no-secrets.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Fail CI if legacy deploy scripts or hardcoded credential patterns reappear.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "Scanning for forbidden deploy scripts and hardcoded secrets..."
+
+if [[ -f deploy_old.py ]]; then
+  echo "::error::deploy_old.py must not be committed (use deploy.py with env-based credentials)"
+  exit 1
+fi
+
+FAIL=0
+
+scan_file() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+
+  # Hardcoded token/password assignments (exclude env lookups and argparse help).
+  while IFS= read -r match; do
+    [[ -z "$match" ]] && continue
+    if [[ "$match" == *"os.environ"* ]] || [[ "$match" == *"add_argument"* ]] || [[ "$match" == *"help="* ]]; then
+      continue
+    fi
+    echo "::error file=${file}::${match}"
+    FAIL=1
+  done < <(
+    grep -nE '(^|[^.])\b(DEPLOY_TOKEN|SFTP_PASSWORD|password)\s*=\s*["'"'"'][^"'"'"']{4,}["'"'"']' "$file" || true
+  )
+}
+
+scan_file deploy.py
+for script in scripts/*.py; do
+  scan_file "$script"
+done
+
+# Inline SFTP/SSH password literals in Python call sites.
+while IFS= read -r match; do
+  [[ -z "$match" ]] && continue
+  if [[ "$match" == *"args.password"* ]] || [[ "$match" == *"add_argument"* ]]; then
+    continue
+  fi
+  echo "::error::${match}"
+  FAIL=1
+done < <(
+  grep -rnE 'password\s*=\s*["'"'"'][^"'"'"']{4,}["'"'"']' deploy.py scripts/ --include='*.py' || true
+)
+
+if [[ "$FAIL" -ne 0 ]]; then
+  echo "Secret scan failed."
+  exit 1
+fi
+
+echo "No forbidden secrets or legacy deploy scripts found."

--- a/tests/responsive.spec.ts
+++ b/tests/responsive.spec.ts
@@ -38,7 +38,7 @@ test.describe('Responsive Layout Tests', () => {
       expect(bodyWidth).toBeLessThanOrEqual(windowWidth + 1); // +1 for rounding
 
       // Check that main elements are visible
-      const panels = await page.locator('.rb-panel').count();
+      const panels = await page.locator('.rb-rack, .rb-panel').count();
       expect(panels).toBeGreaterThan(0);
 
       // Verify no horizontal scrollbar (except when intentional)
@@ -86,26 +86,24 @@ test.describe('Responsive Layout Tests', () => {
     await page.goto(TEST_URL);
     await page.waitForLoadState('networkidle');
 
-    // Test tapping a step button
-    const stepButtons = await page.locator('.rb-step-btn');
-    if (await stepButtons.count() > 0) {
-      const firstButton = stepButtons.first();
-      
-      // Simulate touch tap
-      await firstButton.tap();
+    const player = page.locator('.rbs-player');
+    await player.scrollIntoViewIfNeeded();
 
-      // Check if button has :active or focus styles applied
-      // (Visual verification would be better, but this at least ensures no errors)
-      expect(firstButton).toBeDefined();
+    // Interact with the demo selector (avoid #rbsBtnLoad — it opens a native file picker)
+    const demoSelect = page.locator('#rbsDemoSelect');
+    await expect(demoSelect).toBeVisible();
+    if (test.info().project.use.hasTouch) {
+      await demoSelect.tap();
+    } else {
+      await demoSelect.click();
     }
 
-    // Test knob interaction
-    const knobs = await page.locator('.rb-knob');
+    const knobs = page.locator('.rb-knob');
     if (await knobs.count() > 0) {
       const firstKnob = knobs.first();
-      
-      // Hover over knob to check for hover states
-      await firstKnob.hover();
+      if (await firstKnob.isVisible()) {
+        await firstKnob.hover();
+      }
       
       // Check if element is interactive
       expect(firstKnob).toBeDefined();
@@ -118,7 +116,7 @@ test.describe('Responsive Layout Tests', () => {
     await page.waitForLoadState('networkidle');
 
     // Check that panels don't have excessive margins
-    const panels = await page.locator('.rb-panel');
+    const panels = await page.locator('.rb-rack, .rb-panel');
     expect(await panels.count()).toBeGreaterThan(0);
 
     // Verify action buttons are centered and accessible on mobile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds GitHub Actions workflows to gate pull requests and automate WASM builds.

### `ci.yml` (PR + `main`)
- `npm ci` → `astro check` → production build
- Secrets scan via `scripts/check-no-secrets.sh` (blocks `deploy_old.py` and hardcoded credential patterns)
- Non-blocking `check-mod-metadata.py --priority` warning
- Playwright against the **preview server** (Chromium only in CI)
- Uploads Playwright HTML report + `test-results/` on failure

### `wasm.yml` (PRs touching `src/wasm/**`, nightly cron)
- Pinned Emscripten **3.1.74** via `mymindstorm/setup-emsdk@v14` with cache
- `npm run wasm:build` (release) + production build
- WASM Playwright tests with `WASM_BUILT=1`
- Uploads `public/wasm/` artifacts (14-day retention)

### Other changes
- **`package.json`**: `check`, `ci`, updated `wasm:build`; Node engines pinned to `>=18.17.1 <23`
- **`playwright.config.ts`**: preview server in CI, Chromium-only projects, skip WASM specs unless `WASM_BUILT=1`, GitHub reporter
- **`tests/responsive.spec.ts`**: selector + interaction fixes so CI passes against current markup
- **`README.md`**: new Continuous Integration section — **no repository secrets required** for public CI

## Acceptance

- [x] PRs will show green/red status checks once merged workflow files land on `main`
- [x] Documented that no GitHub secrets are needed for public CI
- [x] Local verification: `npm run check`, `CI=true npm test` (12 passed, 1 skipped)

## Notes

- Main CI intentionally skips `tests/wasm-*.spec.ts` (no WASM artifacts in the default pipeline). WASM tests run in `wasm.yml` after the Emscripten build.
- Mod metadata coverage is a **warning-only** step (`continue-on-error: true`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6436c7b-3750-4b56-8747-a5885f638f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6436c7b-3750-4b56-8747-a5885f638f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

