### PR TITLE
Implement TB-303 voice DSP for archive preview playback

### DIFF
--- a/src/wasm/cpp/Makefile
+++ b/src/wasm/cpp/Makefile
@@ -11,7 +11,7 @@ ENGINE_SRCS = engine/RbsAudioEngine.cpp engine/Sequencer.cpp engine/Mixer.cpp \
               synth/Voice.cpp synth/DrumSynth.cpp synth/Tb303Voice.cpp \
               synth/Tr808Voice.cpp synth/Tr909Voice.cpp
 TEST_SRCS  = tests/test_main.cpp tests/test_parser.cpp tests/test_sequencer.cpp \
-             tests/test_engine.cpp tests/test_drums.cpp
+             tests/test_engine.cpp tests/test_drums.cpp tests/test_tb303.cpp
 TEST_BIN   = $(BUILD_DIR)/test_rbs_parser
 
 .PHONY: all test wasm clean inspect

--- a/src/wasm/cpp/synth/Tb303Voice.cpp
+++ b/src/wasm/cpp/synth/Tb303Voice.cpp
@@ -1,74 +1,212 @@
 #include "Tb303Voice.h"
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 
 namespace rb338 {
 
+namespace {
+
+constexpr float kPi = 3.141592653589793f;
+constexpr float kTwoPi = 2.0f * kPi;
+constexpr float kOutputGain = 0.22f;
+
+float clamp01(float v) { return std::clamp(v, 0.0f, 1.0f); }
+
+float lerp(float a, float b, float t) { return a + (b - a) * t; }
+
+// One-pole smoothing coefficient for ~5 ms at the given sample rate.
+float smoothCoeff(float sampleRate) {
+  return 1.0f - std::exp(-1.0f / (0.005f * sampleRate));
+}
+
+float softClip(float x) {
+  const float drive = 1.4f;
+  return std::tanh(x * drive) / std::tanh(drive);
+}
+
+} // anonymous namespace
+
 void Tb303Voice::init(float sampleRate) {
   m_sampleRate = sampleRate;
+  m_pitchGlideCoeff = 1.0f / (0.12f * sampleRate); // ~120 ms slide
   reset();
 }
 
+void Tb303Voice::applyDeviceState(const DeviceState& state) {
+  m_tune = clamp01(state.tune);
+  m_cutoffKnob = clamp01(state.cutoff);
+  m_resonanceKnob = clamp01(state.resonance);
+  m_envModKnob = clamp01(state.envMod);
+  m_decayKnob = clamp01(state.decay);
+  m_accentKnob = clamp01(state.accent);
+  m_waveformSaw = (state.waveform == 0);
+  m_smoothedCutoff = m_cutoffKnob;
+  m_smoothedResonance = m_resonanceKnob;
+  updateDecayCoeffs();
+  processFilterCoeffs(m_smoothedCutoff, m_smoothedResonance);
+}
+
 void Tb303Voice::load(const DeviceState& state, const std::vector<Pattern>& patterns) {
-  m_cutoff = state.cutoff;
-  m_resonance = state.resonance;
-  m_envMod = state.envMod;
-  // Pattern reference is not needed for the test-tone implementation.
   (void)patterns;
+  applyDeviceState(state);
+}
+
+void Tb303Voice::updateDecayCoeffs() {
+  // Map decay knob to envelope time constants (roughly 80 ms – 2.5 s).
+  const float decaySeconds = lerp(0.08f, 2.5f, m_decayKnob);
+  m_decayCoeff = std::exp(-1.0f / (decaySeconds * m_sampleRate));
+  m_releaseCoeff = std::exp(-1.0f / (0.04f * m_sampleRate));
+}
+
+float Tb303Voice::midiToHz(uint8_t midiNote) const {
+  // Tune knob: ±1 semitone over the knob range.
+  const float tuneSemis = lerp(-1.0f, 1.0f, m_tune);
+  const float note = static_cast<float>(midiNote) + tuneSemis;
+  return 440.0f * std::pow(2.0f, (note - 69.0f) / 12.0f);
+}
+
+void Tb303Voice::processFilterCoeffs(float cutoffNorm, float resonanceNorm) {
+  // Cutoff maps logarithmically from ~120 Hz to ~8 kHz (below Nyquist/4).
+  const float minHz = 120.0f;
+  const float maxHz = 8000.0f;
+  const float hz = minHz * std::pow(maxHz / minHz, clamp01(cutoffNorm));
+  const float wc = kTwoPi * hz / m_sampleRate;
+  // One-pole smoothing coefficient — always < 1 for stability.
+  m_filterG = 1.0f - std::exp(-std::clamp(wc, 0.0f, 3.0f));
+  (void)resonanceNorm;
+}
+
+float Tb303Voice::renderSample() {
+  const float smoothK = smoothCoeff(m_sampleRate);
+  m_smoothedCutoff += (m_cutoffKnob - m_smoothedCutoff) * smoothK;
+  m_smoothedResonance += (m_resonanceKnob - m_smoothedResonance) * smoothK;
+
+  // Portamento toward target pitch.
+  if (std::fabs(m_targetPitch - m_currentPitch) > 0.01f) {
+    const float delta = m_targetPitch - m_currentPitch;
+    m_currentPitch += delta * std::min(1.0f, m_pitchGlideCoeff);
+  } else {
+    m_currentPitch = m_targetPitch;
+  }
+
+  // Oscillator — phase is not reset on note changes.
+  const float phaseInc = m_currentPitch / m_sampleRate;
+  m_phase += phaseInc;
+  if (m_phase >= 1.0f) m_phase -= 1.0f;
+
+  float osc = 0.0f;
+  if (m_waveformSaw) {
+    osc = 2.0f * m_phase - 1.0f;
+  } else {
+    osc = (m_phase < 0.5f) ? 1.0f : -1.0f;
+  }
+
+  // Envelope: instant attack while gate is open, exponential decay.
+  if (m_gateOpen) {
+    m_envelope = std::max(m_envelope * m_decayCoeff, 0.0001f);
+  } else {
+    m_envelope *= m_releaseCoeff;
+  }
+
+  // Filter cutoff: base knob + envelope modulation + accent boost.
+  const float envCutoff = m_envModKnob * m_envelope;
+  const float accentCutoff = m_stepAccent * 0.35f;
+  const float modCutoff = clamp01(m_smoothedCutoff + envCutoff + accentCutoff);
+  processFilterCoeffs(modCutoff, m_smoothedResonance);
+
+  // 4-pole ladder with resonance feedback (stable coefficient range).
+  const float res = lerp(0.0f, 3.2f, m_smoothedResonance);
+  float input = osc * m_envelope;
+  const float accentLevel = 1.0f + m_stepAccent * lerp(0.2f, 0.9f, m_accentKnob);
+  input *= accentLevel;
+
+  input -= m_filterStage[3] * res;
+
+  float stage = input;
+  const float g = m_filterG;
+  for (int i = 0; i < 4; ++i) {
+    m_filterStage[i] += g * (stage - m_filterStage[i]);
+    stage = m_filterStage[i];
+  }
+
+  float out = m_filterStage[3];
+  out = softClip(out);
+
+  return out * kOutputGain;
 }
 
 void Tb303Voice::render(float* output, uint32_t numFrames) {
   if (!output || numFrames == 0) return;
 
-  // MIDI note to frequency: f = 440 * 2^((note - 69) / 12).
-  // For the test tone we centre around C2 (MIDI 36) when note is small.
-  const float baseNote = static_cast<float>(m_currentNote);
-  const float freq = 440.0f * std::pow(2.0f, (baseNote - 69.0f) / 12.0f);
-  const float phaseInc = freq / m_sampleRate;
-
   for (uint32_t i = 0; i < numFrames; ++i) {
-    if (m_gateSamples == 0) {
-      output[i] = 0.0f;
-      continue;
-    }
-
-    // Sawtooth test tone.
-    float sample = 2.0f * m_phase - 1.0f;
-
-    m_phase += phaseInc;
-    if (m_phase >= 1.0f) m_phase -= 1.0f;
-
-    // Simple decay envelope while the gate is open.
-    float env = static_cast<float>(m_gateSamples) / GATE_LENGTH_SAMPLES;
-    env = std::sqrt(env); // faster-sounding decay
-    output[i] = sample * env * 0.15f;
-
-    if (m_gateSamples > 0) --m_gateSamples;
+    output[i] = renderSample();
   }
 }
 
 void Tb303Voice::triggerStep(uint8_t stepIndex, const StepData& step) {
   (void)stepIndex;
-  if (!step.active) return;
-  m_currentNote = step.note;
-  m_gateSamples = GATE_LENGTH_SAMPLES;
-  m_phase = 0.0f;
+
+  if (!step.active) {
+    m_gateOpen = false;
+    m_stepAccent = 0.0f;
+    m_prevStepActive = false;
+    m_prevStepSlide = false;
+    return;
+  }
+
+  const bool slideFromPrev = m_prevStepActive && m_prevStepSlide;
+  m_targetPitch = midiToHz(step.note);
+  m_stepAccent = step.accent ? lerp(0.25f, 1.0f, m_accentKnob) : 0.0f;
+
+  if (slideFromPrev) {
+    // Portamento without retriggering the envelope.
+    m_gateOpen = true;
+  } else {
+    m_currentPitch = m_targetPitch;
+    m_envelope = 1.0f;
+    m_gateOpen = true;
+  }
+
+  m_prevStepActive = true;
+  m_prevStepSlide = step.slide;
 }
 
 void Tb303Voice::setParameter(const char* name, float value) {
-  (void)name;
-  (void)value;
-  // TODO: map parameter names to internal state.
+  if (!name) return;
+  const float v = clamp01(value);
+
+  if (std::strcmp(name, "tune") == 0) {
+    m_tune = v;
+  } else if (std::strcmp(name, "cutoff") == 0) {
+    m_cutoffKnob = v;
+  } else if (std::strcmp(name, "resonance") == 0) {
+    m_resonanceKnob = v;
+  } else if (std::strcmp(name, "envMod") == 0 || std::strcmp(name, "env_mod") == 0) {
+    m_envModKnob = v;
+  } else if (std::strcmp(name, "decay") == 0) {
+    m_decayKnob = v;
+    updateDecayCoeffs();
+  } else if (std::strcmp(name, "accent") == 0) {
+    m_accentKnob = v;
+  } else if (std::strcmp(name, "waveform") == 0) {
+    m_waveformSaw = (v < 0.5f);
+  }
 }
 
 void Tb303Voice::reset() {
   m_phase = 0.0f;
   m_envelope = 0.0f;
-  m_currentPitch = 0.0f;
-  m_targetPitch = 0.0f;
-  m_currentNote = 0;
-  m_gateSamples = 0;
-  std::memset(m_filterState, 0, sizeof(m_filterState));
+  m_gateOpen = false;
+  m_currentPitch = 440.0f;
+  m_targetPitch = 440.0f;
+  m_stepAccent = 0.0f;
+  m_prevStepActive = false;
+  m_prevStepSlide = false;
+  std::memset(m_filterStage, 0, sizeof(m_filterStage));
+  m_smoothedCutoff = m_cutoffKnob;
+  m_smoothedResonance = m_resonanceKnob;
+  processFilterCoeffs(m_smoothedCutoff, m_smoothedResonance);
 }
 
 } // namespace rb338

--- a/src/wasm/cpp/synth/Tb303Voice.h
+++ b/src/wasm/cpp/synth/Tb303Voice.h
@@ -9,9 +9,9 @@ namespace rb338 {
  *
  * Features:
  *   - Saw / square waveform selection
- *   - 24dB/octave resonant low-pass filter
+ *   - 24dB/octave resonant low-pass filter (4-pole ladder)
  *   - Accent (increases envelope depth + filter cutoff)
- *   - Slide (portamento between notes)
+ *   - Slide (portamento between consecutive active notes)
  *   - Decay envelope (attack is instantaneous)
  */
 class Tb303Voice : public Voice {
@@ -29,32 +29,51 @@ public:
 private:
   float m_sampleRate = 44100.0f;
 
-  // Oscillator
+  // Device knobs (target values, 0–1 unless noted).
+  float m_tune = 0.5f;
+  float m_cutoffKnob = 0.5f;
+  float m_resonanceKnob = 0.5f;
+  float m_envModKnob = 0.5f;
+  float m_decayKnob = 0.5f;
+  float m_accentKnob = 0.5f;
+  bool m_waveformSaw = true;
+
+  // Smoothed runtime parameters (zipper-noise reduction).
+  float m_smoothedCutoff = 0.5f;
+  float m_smoothedResonance = 0.5f;
+
+  // Oscillator — phase kept continuous across note changes.
   float m_phase = 0.0f;
-  bool m_waveformSaw = true; // false = square
 
-  // Filter (Moog-style ladder approximation)
-  float m_cutoff = 0.5f;
-  float m_resonance = 0.5f;
-  float m_envMod = 0.5f;
-  float m_filterState[4] = {0};
+  // 4-pole ladder filter state.
+  float m_filterStage[4] = {0};
 
-  // Envelope
+  // Amplitude envelope (instant attack, exponential decay).
   float m_envelope = 0.0f;
-  float m_decayCoeff = 0.99f;
+  float m_decayCoeff = 0.9995f;
+  float m_releaseCoeff = 0.995f;
+  bool m_gateOpen = false;
 
-  // Accent / slide
-  float m_accentAmount = 0.0f;
-  float m_slideRate = 0.0f;
-  float m_currentPitch = 0.0f;
-  float m_targetPitch = 0.0f;
+  // Pitch (Hz) with portamento.
+  float m_currentPitch = 440.0f;
+  float m_targetPitch = 440.0f;
+  float m_pitchGlideCoeff = 0.002f;
 
-  // Test-tone state (will be replaced by full DSP in a later pass)
-  uint8_t m_currentNote = 0;
-  uint32_t m_gateSamples = 0;
-  static constexpr uint32_t GATE_LENGTH_SAMPLES = 11025; // ~0.25s at 44.1kHz
+  // Per-step accent boost (0 = normal, >0 = accented).
+  float m_stepAccent = 0.0f;
 
-  // TODO: full DSP implementation
+  // Slide chain: previous step had slide flag set while active.
+  bool m_prevStepActive = false;
+  bool m_prevStepSlide = false;
+
+  // Filter precomputed coefficient (updated when cutoff moves).
+  float m_filterG = 0.1f;
+
+  void applyDeviceState(const DeviceState& state);
+  void updateDecayCoeffs();
+  float midiToHz(uint8_t midiNote) const;
+  float renderSample();
+  void processFilterCoeffs(float cutoffNorm, float resonanceNorm);
 };
 
 } // namespace rb338

--- a/src/wasm/cpp/tests/test_tb303.cpp
+++ b/src/wasm/cpp/tests/test_tb303.cpp
@@ -1,0 +1,152 @@
+#include "../engine/RbsAudioEngine.h"
+#include "../synth/Tb303Voice.h"
+#include "../third_party/doctest.h"
+#include <cmath>
+#include <cstdint>
+
+using namespace rb338;
+
+namespace {
+
+float renderPeak(Tb303Voice& voice, uint32_t frames = 4096) {
+  float peak = 0.0f;
+  float buffer[512];
+  uint32_t rendered = 0;
+  while (rendered < frames) {
+    const uint32_t block = std::min<uint32_t>(512, frames - rendered);
+    voice.render(buffer, block);
+    for (uint32_t i = 0; i < block; ++i) {
+      peak = std::max(peak, std::fabs(buffer[i]));
+    }
+    rendered += block;
+  }
+  return peak;
+}
+
+DeviceState default303State() {
+  DeviceState state{};
+  state.cutoff = 0.65f;
+  state.resonance = 0.45f;
+  state.envMod = 0.55f;
+  state.decay = 0.5f;
+  state.accent = 0.7f;
+  state.waveform = 0;
+  return state;
+}
+
+StepData activeNote(uint8_t midi, bool accent = false, bool slide = false) {
+  StepData step{};
+  step.active = true;
+  step.note = midi;
+  step.accent = accent;
+  step.slide = slide;
+  return step;
+}
+
+ParsedSong make303Song() {
+  ParsedSong song;
+  song.bpm = 120.0f;
+  for (int i = 0; i < NUM_DEVICES; ++i) {
+    song.devices[i].id = static_cast<DeviceId>(i);
+    song.devices[i].level = 0.9f;
+    song.devices[i].pan = 0.5f;
+  }
+
+  Pattern p;
+  p.deviceId = DeviceId::TB303_A;
+  p.bank = 0;
+  p.patternIndex = 0;
+  p.length = 16;
+  for (int s = 0; s < 16; ++s) {
+    p.steps[s] = activeNote(static_cast<uint8_t>(48 + (s % 5) * 2));
+    p.steps[s].accent = (s % 4 == 0);
+    if (s > 0 && s % 3 == 0) {
+      p.steps[static_cast<size_t>(s - 1)].slide = true;
+    }
+  }
+  song.patterns.push_back(p);
+  song.devices[0].initialPatternBank = 0;
+  song.devices[0].initialPatternIndex = 0;
+  return song;
+}
+
+EngineConfig tb303OnlyConfig() {
+  EngineConfig cfg;
+  cfg.sampleRate = 44100.0f;
+  cfg.bufferSize = 128;
+  cfg.enableTb303A = true;
+  cfg.enableTb303B = false;
+  cfg.enableTr808 = false;
+  cfg.enableTr909 = false;
+  return cfg;
+}
+
+} // namespace
+
+TEST_CASE("Tb303Voice: triggered note produces audible output") {
+  Tb303Voice voice;
+  voice.init(44100.0f);
+  voice.load(default303State(), {});
+
+  voice.triggerStep(0, activeNote(48));
+  const float peak = renderPeak(voice);
+  CHECK(peak > 0.01f);
+}
+
+TEST_CASE("Tb303Voice: square waveform produces output") {
+  Tb303Voice voice;
+  voice.init(44100.0f);
+  DeviceState state = default303State();
+  state.waveform = 1;
+  voice.load(state, {});
+
+  voice.triggerStep(0, activeNote(52));
+  CHECK(renderPeak(voice) > 0.01f);
+}
+
+TEST_CASE("Tb303Voice: accent is louder than non-accent") {
+  Tb303Voice voice;
+  voice.init(44100.0f);
+  voice.load(default303State(), {});
+
+  voice.triggerStep(0, activeNote(48, false));
+  const float normalPeak = renderPeak(voice, 2048);
+
+  voice.reset();
+  voice.triggerStep(0, activeNote(48, true));
+  const float accentPeak = renderPeak(voice, 512);
+
+  CHECK(accentPeak > normalPeak);
+}
+
+TEST_CASE("Tb303Voice: slide chain keeps sound alive across two notes") {
+  Tb303Voice voice;
+  voice.init(44100.0f);
+  voice.load(default303State(), {});
+
+  voice.triggerStep(0, activeNote(48, false, true));
+  renderPeak(voice, 2205);
+
+  voice.triggerStep(1, activeNote(55, false, false));
+  const float afterSlidePeak = renderPeak(voice, 2205);
+  CHECK(afterSlidePeak > 0.005f);
+}
+
+TEST_CASE("Engine: TB-303 pattern produces non-silent audio") {
+  RbsAudioEngine eng;
+  REQUIRE(eng.init(tb303OnlyConfig()));
+  REQUIRE(eng.loadSong(make303Song()));
+
+  float buffer[256] = {0};
+  float* buffers[1] = {buffer};
+
+  eng.play();
+  float peak = 0.0f;
+  for (int i = 0; i < 200; ++i) {
+    eng.processBlock(buffers, 2, 128);
+    for (int s = 0; s < 256; ++s) {
+      peak = std::max(peak, std::fabs(buffer[s]));
+    }
+  }
+  CHECK(peak > 0.01f);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the silent `Tb303Voice` test-tone stub with a monophonic TB-303 synthesis path suitable for in-browser archive previews.

## MVP features

- **Oscillators** — saw / square selection with continuous phase across note changes
- **Filter** — stable 4-pole resonant low-pass (ladder approximation)
- **Envelope** — instant attack + exponential decay; env-mod drives cutoff
- **Accent** — level boost + cutoff lift on accented steps
- **Slide** — portamento into the next step without envelope retrigger (classic 303 slide semantics)
- **Note mapping** — MIDI note → Hz with tune-knob offset

## Nice-to-have included

- Soft saturation on filter output for squelch at high resonance
- Per-block parameter smoothing on cutoff/resonance to reduce zipper noise

## Testing

Added `tests/test_tb303.cpp` covering:

- Basic audible output (saw + square)
- Accent louder than non-accent
- Slide chain sustains across consecutive notes
- Engine integration (`RbsAudioEngine` + sequencer → non-silent mix)

All 28 native C++ tests pass (`make test` in `src/wasm/cpp/`).

## Notes

- Pure C++ — no external DSP dependencies
- Filter coefficients are clamped for stability at high resonance + accent combinations
- ReBirth-specific response curves / lookup tables remain future work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e335f456-3ae7-44dd-9c8a-25078a4b33b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e335f456-3ae7-44dd-9c8a-25078a4b33b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

