### PR TITLE
Implement WASM mixer FX: stereo pan, distortion, tempo delay, limiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": "latest"
+        "node": ">=18.17.1 <23"
       }
     },
     "node_modules/@astrojs/check": {

--- a/src/wasm/audio-module.config.js
+++ b/src/wasm/audio-module.config.js
@@ -64,6 +64,16 @@ export const wasmAudioConfig = {
     compressor: true,
     delay:      true,
   },
+
+  /**
+   * Master volume ownership
+   * ───────────────────────
+   * Playback volume (0–1) is applied inside WASM by RbsAudioEngine::setVolume()
+   * after the Mixer renders each block. The JS GainNode in WasmAudioBridge stays
+   * at unity (1.0) and exists only as a graph tap / future mute hook — do not
+   * drive user-facing level from both layers.
+   */
+  masterVolumeOwner: 'wasm',
 };
 
 /**
@@ -86,4 +96,5 @@ export const wasmAudioConfig = {
  * @property {number}         bufferSize      - Render quantum size in frames
  * @property {number}         maxVoices       - TB-303 polyphony limit
  * @property {EngineFeatures} features        - Per-module feature flags
+ * @property {'wasm'}         masterVolumeOwner - Where playback gain is applied
  */

--- a/src/wasm/cpp/Makefile
+++ b/src/wasm/cpp/Makefile
@@ -11,7 +11,8 @@ ENGINE_SRCS = engine/RbsAudioEngine.cpp engine/Sequencer.cpp engine/Mixer.cpp \
               synth/Voice.cpp synth/DrumSynth.cpp synth/Tb303Voice.cpp \
               synth/Tr808Voice.cpp synth/Tr909Voice.cpp
 TEST_SRCS  = tests/test_main.cpp tests/test_parser.cpp tests/test_sequencer.cpp \
-             tests/test_engine.cpp tests/test_drums.cpp tests/test_tb303.cpp
+             tests/test_engine.cpp tests/test_drums.cpp tests/test_tb303.cpp \
+             tests/test_mixer.cpp
 TEST_BIN   = $(BUILD_DIR)/test_rbs_parser
 
 .PHONY: all test wasm clean inspect

--- a/src/wasm/cpp/engine/Mixer.cpp
+++ b/src/wasm/cpp/engine/Mixer.cpp
@@ -5,12 +5,76 @@
 
 namespace rb338 {
 
+namespace {
+
+constexpr float kDenormalThreshold = 1e-15f;
+constexpr float kDistortionDrive = 5.0f;
+constexpr float kDistortionMix = 0.65f;
+constexpr float kCompressorThreshold = 0.55f;
+constexpr float kCompressorRatio = 4.0f;
+constexpr float kCompressorAttack = 0.003f;   // seconds
+constexpr float kCompressorRelease = 0.08f;   // seconds
+constexpr float kLimiterThreshold = 0.92f;
+constexpr float kLimiterRelease = 0.02f;      // seconds
+
+} // anonymous namespace
+
+float Mixer::flushDenormal(float x) {
+  return (std::fabs(x) < kDenormalThreshold) ? 0.0f : x;
+}
+
+float Mixer::constantPowerPanLeft(float pan) {
+  // pan 0 = hard left, 0.5 = centre, 1 = hard right
+  const float angle = pan * 1.57079632679f; // pi/2
+  return std::cos(angle);
+}
+
+float Mixer::constantPowerPanRight(float pan) {
+  const float angle = pan * 1.57079632679f;
+  return std::sin(angle);
+}
+
+float Mixer::diodeDistort(float x) {
+  // Asymmetric soft clip — ReBirth-style diode distortion character.
+  const float driven = x * kDistortionDrive;
+  if (driven >= 0.0f) {
+    return 1.0f - std::exp(-driven);
+  }
+  return -1.0f + std::exp(driven);
+}
+
+float Mixer::compressSample(float x, float& envelope) const {
+  const float absX = std::fabs(x);
+  const float attackCoeff = std::exp(-1.0f / (kCompressorAttack * m_sampleRate));
+  const float releaseCoeff = std::exp(-1.0f / (kCompressorRelease * m_sampleRate));
+  const float coeff = (absX > envelope) ? attackCoeff : releaseCoeff;
+  envelope = absX + coeff * (envelope - absX);
+
+  if (envelope <= kCompressorThreshold) {
+    return x;
+  }
+
+  const float over = envelope - kCompressorThreshold;
+  const float gainReduction = kCompressorThreshold + over / kCompressorRatio;
+  const float gain = (envelope > 1e-8f) ? gainReduction / envelope : 1.0f;
+  return x * gain;
+}
+
 void Mixer::init(float sampleRate) {
-  m_sampleRate = sampleRate;
+  m_sampleRate = std::max(sampleRate, 1000.0f);
+  m_delayLine.fill(0.0f);
+  m_delayWritePos = 0;
+  m_delayTapSamples = 0;
+  m_limiterEnvelope = 0.0f;
+  m_compressorEnvelopes.fill(0.0f);
+
   for (auto& dev : m_devices) {
     dev.level = 0.8f;
     dev.pan = 0.5f;
     dev.muted = false;
+    dev.dist = false;
+    dev.compressor = false;
+    dev.delaySend = 0.0f;
   }
 }
 
@@ -18,33 +82,117 @@ void Mixer::setDeviceStates(const std::array<DeviceState, NUM_DEVICES>& devices)
   m_devices = devices;
 }
 
-void Mixer::process(const float* const* deviceBuffers, float* stereoOut, uint32_t numFrames) {
-  if (!stereoOut || numFrames == 0) return;
+void Mixer::updateDelayTap(float bpm) {
+  const float clampedBpm = std::clamp(bpm, 40.0f, 250.0f);
+  // One 16th-note step (ReBirth master step) — tempo-sync delay subdivision.
+  const float samplesPerStep = (60.0f / clampedBpm) * 0.25f * m_sampleRate;
+  const uint32_t tap = static_cast<uint32_t>(std::round(samplesPerStep));
+  m_delayTapSamples = std::clamp(tap, 1u, static_cast<uint32_t>(MAX_DELAY_SAMPLES - 1));
+}
 
-  std::memset(stereoOut, 0, numFrames * 2 * sizeof(float));
-
-  for (int d = 0; d < NUM_DEVICES; ++d) {
-    const float* src = deviceBuffers[d];
-    if (!src) continue;
-    if (m_devices[d].muted) continue;
-
-    const float level = std::clamp(m_devices[d].level, 0.0f, 1.0f);
-    const float pan = std::clamp(m_devices[d].pan, 0.0f, 1.0f);
-    // Linear pan law: left gain = (1 - pan) * level, right gain = pan * level.
-    const float leftGain = (1.0f - pan) * 2.0f * level;
-    const float rightGain = pan * 2.0f * level;
-
-    for (uint32_t i = 0; i < numFrames; ++i) {
-      const float s = src[i];
-      stereoOut[i * 2 + 0] += s * leftGain;
-      stereoOut[i * 2 + 1] += s * rightGain;
-    }
+void Mixer::processDelaySample(float input, float& outL, float& outR) {
+  if (!m_delayOn || m_delayTapSamples == 0) {
+    outL = 0.0f;
+    outR = 0.0f;
+    return;
   }
 
-  // Soft clip / cheap limiter to avoid hard digital clipping when many voices
-  // hit simultaneously.
-  for (uint32_t i = 0; i < numFrames * 2; ++i) {
-    stereoOut[i] = std::tanh(stereoOut[i]);
+  const uint32_t readPos =
+      (m_delayWritePos + MAX_DELAY_SAMPLES - m_delayTapSamples) % MAX_DELAY_SAMPLES;
+  const float delayed = m_delayLine[readPos];
+
+  m_delayLine[m_delayWritePos] =
+      flushDenormal(input + delayed * m_delayFeedback);
+  m_delayWritePos = (m_delayWritePos + 1) % MAX_DELAY_SAMPLES;
+
+  const float wet = delayed * m_delayWet;
+  outL = wet;
+  outR = wet;
+}
+
+void Mixer::process(const float* const* deviceBuffers, float* stereoOut,
+                    uint32_t numFrames, float bpm) {
+  if (!stereoOut || numFrames == 0) return;
+
+  updateDelayTap(bpm);
+  std::memset(stereoOut, 0, numFrames * 2 * sizeof(float));
+
+  const float limiterReleaseCoeff =
+      std::exp(-1.0f / (kLimiterRelease * m_sampleRate));
+
+  for (uint32_t frame = 0; frame < numFrames; ++frame) {
+    float dryL = 0.0f;
+    float dryR = 0.0f;
+    float distBus = 0.0f;
+    float delayBus = 0.0f;
+
+    for (int d = 0; d < NUM_DEVICES; ++d) {
+      const float* src = deviceBuffers[d];
+      if (!src) continue;
+      if (m_devices[d].muted) continue;
+
+      float sample = flushDenormal(src[frame]);
+      const float level = std::clamp(m_devices[d].level, 0.0f, 1.0f);
+      const float pan = std::clamp(m_devices[d].pan, 0.0f, 1.0f);
+
+      if (m_compressorOn && m_devices[d].compressor) {
+        // Per-device compressor send — gentle bus compression before pan.
+        sample = compressSample(sample * level, m_compressorEnvelopes[d]);
+      } else {
+        sample *= level;
+      }
+
+      const float leftGain = constantPowerPanLeft(pan);
+      const float rightGain = constantPowerPanRight(pan);
+      dryL += sample * leftGain;
+      dryR += sample * rightGain;
+
+      if (m_distortionOn && m_devices[d].dist) {
+        distBus += sample;
+      }
+
+      if (m_delayOn) {
+        const float send = std::clamp(m_devices[d].delaySend, 0.0f, 1.0f);
+        if (send > 0.0f) {
+          delayBus += sample * send;
+        }
+      }
+    }
+
+    float wetL = 0.0f;
+    float wetR = 0.0f;
+
+    if (m_distortionOn && std::fabs(distBus) > kDenormalThreshold) {
+      const float distorted = diodeDistort(distBus);
+      const float wet = distorted * kDistortionMix;
+      wetL += wet;
+      wetR += wet;
+    }
+
+    if (m_delayOn) {
+      float delayL = 0.0f;
+      float delayR = 0.0f;
+      processDelaySample(delayBus, delayL, delayR);
+      wetL += delayL;
+      wetR += delayR;
+    }
+
+    float outL = flushDenormal(dryL + wetL);
+    float outR = flushDenormal(dryR + wetR);
+
+    if (m_compressorOn) {
+      // Master peak limiter — prevents hard digital clips on the summed bus.
+      const float peak = std::max(std::fabs(outL), std::fabs(outR));
+      const float targetGain =
+          (peak > kLimiterThreshold) ? (kLimiterThreshold / peak) : 1.0f;
+      m_limiterEnvelope =
+          targetGain + limiterReleaseCoeff * (m_limiterEnvelope - targetGain);
+      outL *= m_limiterEnvelope;
+      outR *= m_limiterEnvelope;
+    }
+
+    stereoOut[frame * 2 + 0] = flushDenormal(outL);
+    stereoOut[frame * 2 + 1] = flushDenormal(outR);
   }
 }
 

--- a/src/wasm/cpp/engine/Mixer.h
+++ b/src/wasm/cpp/engine/Mixer.h
@@ -10,13 +10,20 @@ namespace rb338 {
  * Mixer — 4-channel stereo mixer + master FX bus.
  *
  * Processes one render quantum (128 frames) at a time.
- * Per-device level, pan, and mute come from the loaded song's DeviceState.
+ * Per-device level, pan, mute, and FX sends come from the loaded song's
+ * DeviceState. Global FX modules honour EngineConfig feature flags.
+ *
+ * Master output level is applied by RbsAudioEngine after this mix (WASM-side).
+ * The JS GainNode in WasmAudioBridge stays at unity — see audio-module.config.js.
  */
 class Mixer {
 public:
+  /** Maximum delay line length (~0.45 s @ 44.1 kHz). Allocated once in init(). */
+  static constexpr size_t MAX_DELAY_SAMPLES = 20000;
+
   Mixer() = default;
 
-  /** Initialise internal delay lines, filter states, etc. */
+  /** Initialise internal delay lines, filter states, etc. (no heap alloc). */
   void init(float sampleRate);
 
   /** Copy mixer routing from the loaded song (main thread). */
@@ -28,22 +35,42 @@ public:
    * @param deviceBuffers  4 pointers to mono float buffers (one per device)
    * @param stereoOut      Interleaved stereo output [L,R,L,R,...]
    * @param numFrames      Number of frames to process
+   * @param bpm            Effective tempo (BPM) for tempo-sync delay
    */
-  void process(const float* const* deviceBuffers, float* stereoOut, uint32_t numFrames);
+  void process(const float* const* deviceBuffers, float* stereoOut, uint32_t numFrames,
+               float bpm);
 
-  /** Enable/disable master FX. */
   void setDistortionEnabled(bool on) { m_distortionOn = on; }
   void setCompressorEnabled(bool on) { m_compressorOn = on; }
   void setDelayEnabled(bool on) { m_delayOn = on; }
 
 private:
+  static float flushDenormal(float x);
+  static float constantPowerPanLeft(float pan);
+  static float constantPowerPanRight(float pan);
+  static float diodeDistort(float x);
+  float compressSample(float x, float& envelope) const;
+  void updateDelayTap(float bpm);
+  void processDelaySample(float input, float& outL, float& outR);
+
   float m_sampleRate = 44100.0f;
   bool m_distortionOn = true;
   bool m_compressorOn = true;
   bool m_delayOn = true;
   std::array<DeviceState, NUM_DEVICES> m_devices{};
 
-  // TODO: delay line, compressor state, distortion state
+  // Tempo-sync delay (fixed allocation in init, no heap in process).
+  std::array<float, MAX_DELAY_SAMPLES> m_delayLine{};
+  uint32_t m_delayWritePos = 0;
+  uint32_t m_delayTapSamples = 0;
+  float m_delayFeedback = 0.38f;
+  float m_delayWet = 0.45f;
+
+  // Master peak limiter envelope (stereo-linked).
+  float m_limiterEnvelope = 0.0f;
+
+  // Per-device compressor envelope followers (compressor-send path).
+  std::array<float, NUM_DEVICES> m_compressorEnvelopes{};
 };
 
 } // namespace rb338

--- a/src/wasm/cpp/engine/RbsAudioEngine.cpp
+++ b/src/wasm/cpp/engine/RbsAudioEngine.cpp
@@ -49,6 +49,9 @@ bool RbsAudioEngine::init(const EngineConfig& config) {
   }
 
   m_mixer->init(config.sampleRate);
+  m_mixer->setDistortionEnabled(config.enableDistortion);
+  m_mixer->setCompressorEnabled(config.enableCompressor);
+  m_mixer->setDelayEnabled(config.enableDelay);
 
   m_sequencer->reset();
   m_currentBar.store(1, std::memory_order_relaxed);
@@ -242,9 +245,9 @@ void RbsAudioEngine::processBlock(float* const* outputBuffers,
 
   // Mix into final stereo interleaved output.
   if (stereoOut && numChannels >= 2) {
-    m_mixer->process(m_voiceBuffers.data(), stereoOut, numFrames);
+    m_mixer->process(m_voiceBuffers.data(), stereoOut, numFrames, effectiveBpm);
 
-    // Apply master volume.
+    // Master volume — sole user-facing gain stage (JS GainNode stays at unity).
     float vol = m_volume.load(std::memory_order_relaxed);
     for (uint32_t i = 0; i < numFrames * 2; ++i) {
       stereoOut[i] *= vol;

--- a/src/wasm/cpp/parser/RbsFormat.md
+++ b/src/wasm/cpp/parser/RbsFormat.md
@@ -168,7 +168,7 @@ Each 12-byte mixer record:
 | 0 | Mute (0 = muted) |
 | 1 | Level 0–127 |
 | 2 | Pan 0–127 (64 = centre) |
-| 3 | ? |
+| 3 | Delay send 0–127 |
 | 4 | Distortion send (0/1) |
 | 5 | PCF send (0/1) |
 | 6 | Compressor send (0/1) |

--- a/src/wasm/cpp/parser/RbsParser.cpp
+++ b/src/wasm/cpp/parser/RbsParser.cpp
@@ -426,6 +426,7 @@ bool RbsParser::parseMixr(const uint8_t* data, size_t size, ParsedSong& song) {
     dev.level = static_cast<float>(data[off + 1]) / 127.0f;
     dev.pan = static_cast<float>(data[off + 2]) / 127.0f;
     // Offsets 3-7 contain sends/flags; decode the ones we are confident about.
+    dev.delaySend = static_cast<float>(data[off + 3]) / 127.0f;
     dev.dist = (data[off + 4] != 0);
     dev.pcf = (data[off + 5] != 0);
     dev.compressor = (data[off + 6] != 0);

--- a/src/wasm/cpp/tests/test_mixer.cpp
+++ b/src/wasm/cpp/tests/test_mixer.cpp
@@ -1,0 +1,207 @@
+#include "../engine/Mixer.h"
+#include "../third_party/doctest.h"
+#include <array>
+#include <cmath>
+#include <cstring>
+
+using namespace rb338;
+
+namespace {
+
+constexpr uint32_t kFrames = 128;
+
+std::array<float, kFrames> makeImpulse(uint32_t position = 0) {
+  std::array<float, kFrames> buf{};
+  if (position < kFrames) {
+    buf[position] = 1.0f;
+  }
+  return buf;
+}
+
+std::array<float, kFrames> makeConstant(float value) {
+  std::array<float, kFrames> buf{};
+  buf.fill(value);
+  return buf;
+}
+
+float peakChannel(const float* stereo, uint32_t frames, bool right) {
+  float peak = 0.0f;
+  for (uint32_t i = 0; i < frames; ++i) {
+    const float sample = stereo[i * 2 + (right ? 1 : 0)];
+    if (std::isnan(sample) || std::isinf(sample)) {
+      return -1.0f;
+    }
+    peak = std::max(peak, std::fabs(sample));
+  }
+  return peak;
+}
+
+} // namespace
+
+TEST_CASE("Mixer: pan hard-left and hard-right route to one channel") {
+  Mixer mixer;
+  mixer.init(44100.0f);
+
+  auto leftOnly = makeConstant(0.5f);
+  const float* leftInputs[NUM_DEVICES] = {leftOnly.data(), nullptr, nullptr, nullptr};
+
+  std::array<DeviceState, NUM_DEVICES> devices{};
+  devices[0].id = DeviceId::TB303_A;
+  devices[0].level = 1.0f;
+  devices[0].pan = 0.0f; // hard left
+  mixer.setDeviceStates(devices);
+
+  float leftOut[kFrames * 2] = {0};
+  mixer.process(leftInputs, leftOut, kFrames, 120.0f);
+  const float leftOnlyLeft = peakChannel(leftOut, kFrames, false);
+  const float leftOnlyRight = peakChannel(leftOut, kFrames, true);
+  CHECK(leftOnlyLeft > leftOnlyRight);
+  CHECK(leftOnlyLeft > 0.0f);
+
+  devices[0].pan = 1.0f; // hard right
+  mixer.setDeviceStates(devices);
+
+  float rightOut[kFrames * 2] = {0};
+  mixer.process(leftInputs, rightOut, kFrames, 120.0f);
+  const float rightOnlyLeft = peakChannel(rightOut, kFrames, false);
+  const float rightOnlyRight = peakChannel(rightOut, kFrames, true);
+  CHECK(rightOnlyRight > rightOnlyLeft);
+  CHECK(rightOnlyRight > 0.0f);
+}
+
+TEST_CASE("Mixer: silence produces no NaNs or denormals") {
+  Mixer mixer;
+  mixer.init(44100.0f);
+
+  std::array<DeviceState, NUM_DEVICES> devices{};
+  for (int i = 0; i < NUM_DEVICES; ++i) {
+    devices[i].id = static_cast<DeviceId>(i);
+    devices[i].level = 1.0f;
+    devices[i].dist = true;
+    devices[i].compressor = true;
+    devices[i].delaySend = 1.0f;
+  }
+  mixer.setDeviceStates(devices);
+
+  auto silence = makeConstant(0.0f);
+  const float* inputs[NUM_DEVICES] = {
+      silence.data(), silence.data(), silence.data(), silence.data()};
+
+  float out[kFrames * 2] = {0};
+  mixer.process(inputs, out, kFrames, 120.0f);
+
+  for (uint32_t i = 0; i < kFrames * 2; ++i) {
+    CHECK_FALSE(std::isnan(out[i]));
+    CHECK_FALSE(std::isinf(out[i]));
+    CHECK(out[i] == doctest::Approx(0.0f).epsilon(1e-12));
+  }
+}
+
+TEST_CASE("Mixer: distortion send changes the output waveform") {
+  Mixer mixer;
+  mixer.init(44100.0f);
+  mixer.setDistortionEnabled(true);
+  mixer.setDelayEnabled(false);
+  mixer.setCompressorEnabled(false);
+
+  std::array<DeviceState, NUM_DEVICES> devices{};
+  devices[0].id = DeviceId::TB303_A;
+  devices[0].level = 1.0f;
+  devices[0].pan = 0.5f;
+  devices[0].dist = false;
+  mixer.setDeviceStates(devices);
+
+  auto tone = makeConstant(0.6f);
+  const float* inputs[NUM_DEVICES] = {tone.data(), nullptr, nullptr, nullptr};
+
+  float dryOut[kFrames * 2] = {0};
+  mixer.process(inputs, dryOut, kFrames, 120.0f);
+  const float dryPeak = peakChannel(dryOut, kFrames, false);
+
+  devices[0].dist = true;
+  mixer.setDeviceStates(devices);
+  float wetOut[kFrames * 2] = {0};
+  mixer.process(inputs, wetOut, kFrames, 120.0f);
+  const float wetPeak = peakChannel(wetOut, kFrames, false);
+
+  CHECK(wetPeak != doctest::Approx(dryPeak).epsilon(0.01));
+  CHECK(wetPeak > dryPeak);
+}
+
+TEST_CASE("Mixer: delay send produces energy after the tap time") {
+  Mixer mixer;
+  mixer.init(44100.0f);
+  mixer.setDistortionEnabled(false);
+  mixer.setCompressorEnabled(false);
+  mixer.setDelayEnabled(true);
+
+  std::array<DeviceState, NUM_DEVICES> devices{};
+  devices[0].id = DeviceId::TB303_A;
+  devices[0].level = 1.0f;
+  devices[0].pan = 0.5f;
+  devices[0].delaySend = 1.0f;
+  mixer.setDeviceStates(devices);
+
+  auto impulse = makeImpulse(0);
+
+  // 120 BPM → one 16th = 5512.5 samples; process enough blocks to hear echo.
+  const uint32_t delayTap =
+      static_cast<uint32_t>(std::round((60.0f / 120.0f) * 0.25f * 44100.0f));
+  const uint32_t totalFrames = delayTap + 256;
+
+  float earlyPeak = 0.0f;
+  float latePeak = 0.0f;
+
+  std::array<float, 512> block{};
+  float* stereo = block.data();
+  uint32_t rendered = 0;
+  while (rendered < totalFrames) {
+    const uint32_t frames = std::min(kFrames, totalFrames - rendered);
+    std::memset(stereo, 0, frames * 2 * sizeof(float));
+    const float* blockInputs[NUM_DEVICES] = {nullptr, nullptr, nullptr, nullptr};
+    if (rendered < kFrames) {
+      blockInputs[0] = impulse.data();
+    }
+    mixer.process(blockInputs, stereo, frames, 120.0f);
+
+    for (uint32_t i = 0; i < frames; ++i) {
+      const uint32_t globalFrame = rendered + i;
+      const float sample = std::fabs(stereo[i * 2]);
+      if (globalFrame < 4) {
+        earlyPeak = std::max(earlyPeak, sample);
+      }
+      if (globalFrame >= delayTap && globalFrame < delayTap + 64) {
+        latePeak = std::max(latePeak, sample);
+      }
+    }
+    rendered += frames;
+  }
+
+  CHECK(earlyPeak > 0.0f);
+  CHECK(latePeak > 0.0f);
+}
+
+TEST_CASE("Mixer: feature flags disable heavy FX") {
+  Mixer mixer;
+  mixer.init(44100.0f);
+  mixer.setDistortionEnabled(false);
+  mixer.setDelayEnabled(false);
+  mixer.setCompressorEnabled(false);
+
+  std::array<DeviceState, NUM_DEVICES> devices{};
+  devices[0].id = DeviceId::TB303_A;
+  devices[0].level = 1.0f;
+  devices[0].pan = 0.5f;
+  devices[0].dist = true;
+  devices[0].delaySend = 1.0f;
+  mixer.setDeviceStates(devices);
+
+  auto tone = makeConstant(0.8f);
+  const float* inputs[NUM_DEVICES] = {tone.data(), nullptr, nullptr, nullptr};
+
+  float out[kFrames * 2] = {0};
+  mixer.process(inputs, out, kFrames, 120.0f);
+
+  const float peak = peakChannel(out, kFrames, false);
+  CHECK(peak == doctest::Approx(0.8f * 0.70710678f).epsilon(0.05));
+}

--- a/src/wasm/js/WasmAudioBridge.ts
+++ b/src/wasm/js/WasmAudioBridge.ts
@@ -208,6 +208,8 @@ export class WasmAudioBridge {
       if (!this.workletNode) {
         throw new Error('AudioWorklet node was not created');
       }
+      // GainNode stays at unity — master volume is applied in WASM (see
+      // audio-module.config.js masterVolumeOwner).
       this.gainNode = this.audioContext.createGain();
       this.gainNode.gain.value = 1.0;
       this.workletNode.connect(this.gainNode);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the placeholder `Mixer` with a real-time DSP path for the WASM audio engine.

- **Stereo bus**: constant-power panning per device (level + pan from `DeviceState`)
- **Distortion send**: ReBirth-style asymmetric diode soft-clip on devices with `dist` enabled
- **Tempo-sync delay**: 16th-note (one sequencer step) delay tap driven by `delaySend` and song BPM
- **Master limiter**: peak limiter on the summed bus when the compressor feature flag is on; per-device `compressor` send applies gentle compression before pan
- **DSP constraints**: fixed `MAX_DELAY_SAMPLES` delay line allocated in `init()` only; no heap allocation in `processBlock`
- **Feature flags**: `enableDistortion`, `enableDelay`, `enableCompressor` from `EngineConfig` / `audio-module.config.js` gate FX modules
- **Volume ownership**: documented that WASM (`RbsAudioEngine::setVolume`) owns playback gain; JS `GainNode` stays at unity

Also decodes MIXR byte 3 as `delaySend` and adds native unit tests (`test_mixer.cpp`).

## Test plan

- [x] `cd src/wasm/cpp && make test` — 33/33 tests pass (pan, silence/NaN, distortion, delay tail, feature flags)
- [x] `npm run astro check` — 0 errors
- [ ] Manual: load an `.rbs` with distortion/delay sends enabled and verify audible FX (requires WASM build)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df8052aa-747b-40ba-92ff-0105c6ff9561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df8052aa-747b-40ba-92ff-0105c6ff9561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

