### PR TITLE
Archive song preview UX — Play buttons, deep-links, metadata panel

### DIFF
--- a/src/components/ModCard.astro
+++ b/src/components/ModCard.astro
@@ -161,6 +161,8 @@ const typeClass = isSong ? 'type--song' : isMod ? 'type--mod' : 'type--other';
 </article>
 
 <script>
+  import { dispatchLoadDemo, scrollToPlayer } from '../lib/player-events';
+
   document.querySelectorAll('.mod-card__action--preview').forEach((button) => {
     if (!(button instanceof HTMLButtonElement)) return;
     button.addEventListener('click', () => {
@@ -169,8 +171,8 @@ const typeClass = isSong ? 'type--song' : isMod ? 'type--mod' : 'type--other';
         label: button.dataset.previewLabel ?? 'archive preview',
         bpm: button.dataset.previewBpm ? Number(button.dataset.previewBpm) : undefined,
       };
-      window.dispatchEvent(new CustomEvent('rb:load-demo', { detail }));
-      document.getElementById('wasm-heading')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      dispatchLoadDemo(detail);
+      scrollToPlayer();
     });
   });
 </script>

--- a/src/components/RbsPlayer.astro
+++ b/src/components/RbsPlayer.astro
@@ -39,6 +39,7 @@ const hasSrc = !!src;
   variant="rackmount-module"
   animate
   title={title}
+  id="wasm-heading"
 >
   <div
     class="rbs-player"
@@ -73,10 +74,16 @@ const hasSrc = !!src;
     </div>
 
     <!-- Song metadata display -->
-    <div class="player-meta is-hidden" id="rbsMeta">
-      <span class="meta-title" id="rbsMetaTitle">—</span>
-      <span class="meta-author" id="rbsMetaAuthor">—</span>
+    <div class="player-meta is-hidden" id="rbsMeta" aria-label="Loaded song metadata">
+      <div class="player-meta__primary">
+        <span class="meta-title" id="rbsMetaTitle">—</span>
+        <span class="meta-author" id="rbsMetaAuthor">—</span>
+        <span class="meta-bpm" id="rbsMetaBpm">— BPM</span>
+      </div>
+      <div class="player-meta__devices" id="rbsMetaDevices" aria-label="ReBirth devices"></div>
     </div>
+
+    <div class="player-toast-stack" id="rbsToastStack" aria-live="polite" aria-relevant="additions"></div>
 
     <div class="player-message" id="rbsMessage" aria-live="polite">Ready to initialise WASM bridge…</div>
 
@@ -218,14 +225,25 @@ const hasSrc = !!src;
   /* Metadata strip */
   .player-meta {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-    flex-wrap: wrap;
-    padding: 0.5rem 0.75rem;
+    flex-direction: column;
+    gap: 0.6rem;
+    padding: 0.6rem 0.75rem;
     background: rgba(0, 0, 0, 0.2);
     border-radius: 4px;
     border: 1px solid var(--rb-border, #3a3a3a);
+  }
+
+  .player-meta__primary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem 1rem;
+  }
+
+  .player-meta__devices {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
   }
 
   .meta-title {
@@ -239,6 +257,98 @@ const hasSrc = !!src;
     font-family: var(--rb-font-display, 'Courier New', monospace);
     font-size: 0.75rem;
     color: var(--rb-silver-dim, #888);
+  }
+
+  .meta-bpm {
+    font-family: var(--rb-font-display, 'Courier New', monospace);
+    font-size: 0.7rem;
+    color: var(--rb-green-bright, #3dba66);
+    letter-spacing: 0.06em;
+    padding: 1px 5px;
+    border: 1px solid var(--rb-green-dim, #1a5230);
+    border-radius: 2px;
+    background: rgba(57, 255, 20, 0.06);
+  }
+
+  :global(.meta-device) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 2px 6px;
+    border-radius: 3px;
+    border: 1px solid var(--rb-border, #3a3a3a);
+    background: rgba(0, 0, 0, 0.25);
+    font-family: var(--rb-font-display, 'Courier New', monospace);
+    font-size: 0.65rem;
+    color: var(--rb-silver, #c0c0c0);
+    letter-spacing: 0.05em;
+  }
+
+  :global(.meta-device--muted) {
+    opacity: 0.45;
+  }
+
+  :global(.meta-device__led) {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--rb-green, #2d8a4e);
+    box-shadow: 0 0 4px rgba(57, 255, 20, 0.5);
+  }
+
+  :global(.meta-device--muted .meta-device__led) {
+    background: #555;
+    box-shadow: none;
+  }
+
+  :global(.meta-device__count) {
+    color: var(--rb-silver-dim, #888);
+    font-size: 0.6rem;
+  }
+
+  /* Toast stack */
+  .player-toast-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    pointer-events: none;
+  }
+
+  :global(.player-toast) {
+    padding: 0.45rem 0.65rem;
+    border-radius: 3px;
+    border: 1px solid var(--rb-border, #3a3a3a);
+    background: linear-gradient(180deg, #2a2a2a 0%, #1a1a1a 100%);
+    font-family: var(--rb-font-display, 'Courier New', monospace);
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    color: var(--rb-silver, #c0c0c0);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    animation: toast-in 200ms ease;
+  }
+
+  :global(.player-toast--success) {
+    border-color: var(--rb-green-dim, #1a5230);
+    color: var(--rb-green-bright, #3dba66);
+  }
+
+  :global(.player-toast--error) {
+    border-color: var(--rb-red-dim, #8a1528);
+    color: var(--rb-red, #c41e3a);
+  }
+
+  :global(.player-toast--loading) {
+    border-color: var(--rb-amber-dim, #b37800);
+    color: var(--rb-amber, #ffb000);
+  }
+
+  @keyframes toast-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .player--reduced-motion :global(.player-toast) {
+    animation: none;
   }
 
   .player-message {
@@ -294,10 +404,20 @@ const hasSrc = !!src;
     border-color: var(--rb-red-dim, #8a1528);
   }
 
+  .step-dot.is-pattern {
+    background: linear-gradient(180deg, #4a4a20 0%, #3a3a18 100%);
+    border-color: #5a5a28;
+  }
+
   .step-dot.is-active {
     background: linear-gradient(180deg, var(--rb-amber, #ffb000) 0%, #a07800 100%);
     border-color: var(--rb-amber-dim, #b37800);
     box-shadow: 0 0 6px rgba(255, 176, 0, 0.4);
+  }
+
+  .player--reduced-motion .step-dot,
+  .player--reduced-motion .meter-segment {
+    transition: none;
   }
 
   .step-dot.is-current {
@@ -436,408 +556,25 @@ const hasSrc = !!src;
 <script>
   import { WasmAudioBridge } from '../wasm/js/WasmAudioBridge';
   import { DegradedRbsPlayer } from '../wasm/js/DegradedRbsPlayer';
-  import {
-    classifyInitError,
-    INIT_FAILURE_MESSAGES,
-    type InitFailureReason,
-  } from '../wasm/js/rbs-init-errors';
-  import type { PlayerStatus } from '../wasm/types/wasm-audio';
+  import { initPlayerUI } from '../wasm/js/player-ui';
+  import type { DemoSong } from '../wasm/js/player-ui';
 
-  type PlayerBridge = WasmAudioBridge | DegradedRbsPlayer;
-
-  // Expose bridge classes on window in dev mode so integration tests can
-  // drive them directly without reaching into module internals.
   if (import.meta.env.DEV) {
-    (window as any).WasmAudioBridge = WasmAudioBridge;
-    (window as any).DegradedRbsPlayer = DegradedRbsPlayer;
+    (window as Window & { WasmAudioBridge?: typeof WasmAudioBridge; DegradedRbsPlayer?: typeof DegradedRbsPlayer }).WasmAudioBridge = WasmAudioBridge;
+    (window as Window & { WasmAudioBridge?: typeof WasmAudioBridge; DegradedRbsPlayer?: typeof DegradedRbsPlayer }).DegradedRbsPlayer = DegradedRbsPlayer;
   }
 
-  (async function initRbsPlayer() {
-    const playerEl = document.querySelector('.rbs-player') as HTMLElement | null;
-    if (!playerEl) return;
-
-    const dropZone = document.getElementById('rbsDropZone') as HTMLElement | null;
-    const fileInput = document.getElementById('rbsFileInput') as HTMLInputElement | null;
-    const btnPlay = document.getElementById('rbsBtnPlay') as HTMLButtonElement | null;
-    const btnStop = document.getElementById('rbsBtnStop') as HTMLButtonElement | null;
-    const btnLoad = document.getElementById('rbsBtnLoad') as HTMLButtonElement | null;
-    const metaEl = document.getElementById('rbsMeta') as HTMLElement | null;
-    const metaTitle = document.getElementById('rbsMetaTitle') as HTMLElement | null;
-    const metaAuthor = document.getElementById('rbsMetaAuthor') as HTMLElement | null;
-    const messageEl = document.getElementById('rbsMessage') as HTMLElement | null;
-    const demoSelect = document.getElementById('rbsDemoSelect') as HTMLSelectElement | null;
-    const btnDemoLoad = document.getElementById('rbsBtnDemoLoad') as HTMLButtonElement | null;
-    const volumeSlider = document.getElementById('rbsVolume') as HTMLInputElement | null;
-    const volumeValue = document.getElementById('rbsVolumeValue') as HTMLElement | null;
-    const tempoSlider = document.getElementById('rbsTempo') as HTMLInputElement | null;
-    const tempoValue = document.getElementById('rbsTempoValue') as HTMLElement | null;
-    const fallbackEl = document.getElementById('rbsFallback') as HTMLElement | null;
-    const fallbackHeadline = document.getElementById('rbsFallbackHeadline') as HTMLElement | null;
-    const fallbackDetail = document.getElementById('rbsFallbackDetail') as HTMLElement | null;
-    const fallbackMode = document.getElementById('rbsFallbackMode') as HTMLElement | null;
-    const lcdStatus = playerEl.querySelector('.player-lcd-status .lcd-value') as HTMLElement | null;
-    const lcdBpm = playerEl.querySelector('.player-lcd-bpm .lcd-value') as HTMLElement | null;
-    const lcdBar = playerEl.querySelector('.player-lcd-bar .lcd-value') as HTMLElement | null;
-    const ledLabel = playerEl.querySelector('.player-led') as HTMLElement | null;
-    const stepDots = playerEl.querySelectorAll('.step-dot');
-    const meterSegments = playerEl.querySelectorAll('.meter-segment');
-
-    let bridge: PlayerBridge = new WasmAudioBridge();
-    let degradedMode = false;
-    let songLoaded = false;
-    let canSketch = false;
-
-    const demos = (() => {
-      try {
-        return JSON.parse(playerEl.dataset.demos || '[]') as { label: string; src: string; bpm?: number }[];
-      } catch {
-        return [];
-      }
-    })();
-
-    function setMessage(message: string) {
-      if (messageEl) messageEl.textContent = message;
-    }
-
-    function setPlayerMode(mode: 'wasm' | 'degraded-sketch' | 'degraded-metadata') {
-      if (playerEl) playerEl.dataset.playerMode = mode;
-    }
-
-    function showDegradedFallback(reason: InitFailureReason) {
-      degradedMode = true;
-      if (fallbackEl) {
-        fallbackEl.classList.remove('is-hidden');
-        fallbackEl.dataset.failureReason = reason;
-      }
-      if (fallbackDetail) fallbackDetail.textContent = INIT_FAILURE_MESSAGES[reason];
-      if (fallbackHeadline) {
-        fallbackHeadline.textContent = reason === 'wasm-unavailable'
-          ? 'WASM engine not built'
-          : 'Full playback unavailable';
-      }
-      if (fallbackMode) {
-        fallbackMode.textContent = canSketch
-          ? 'Degraded mode: metadata + metronome sketch preview (not full ReBirth synthesis).'
-          : 'Degraded mode: metadata only — load a file to inspect title and author.';
-      }
-      setPlayerMode(canSketch ? 'degraded-sketch' : 'degraded-metadata');
-    }
-
-    function updatePlayAvailability() {
-      if (!btnPlay) return;
-      if (!degradedMode) {
-        btnPlay.disabled = !songLoaded && bridge.playerStatus !== 'ready' && bridge.playerStatus !== 'playing';
-        return;
-      }
-      btnPlay.disabled = !songLoaded || !canSketch;
-      btnPlay.title = canSketch
-        ? (songLoaded ? 'Play sketch preview (metronome)' : 'Load a song first')
-        : 'Sketch preview unavailable — metadata only';
-    }
-
-    // ── Status updates ──────────────────────────────────────────────
-
-    function setStatus(status: PlayerStatus) {
-      if (!lcdStatus || !ledLabel) return;
-
-      const labelText = ledLabel.querySelector('.rb-led__label');
-
-      switch (status) {
-        case 'idle':
-          lcdStatus.textContent = 'IDLE';
-          ledLabel.className = 'rb-led rb-led--pending player-led';
-          if (labelText) labelText.textContent = degradedMode ? 'DEGRADED' : 'PENDING';
-          if (btnPlay) {
-            btnPlay.textContent = '▶';
-            btnPlay.title = 'Play';
-            btnPlay.setAttribute('aria-label', 'Play');
-          }
-          break;
-        case 'loading':
-          lcdStatus.textContent = 'LOAD…';
-          ledLabel.className = 'rb-led rb-led--pending player-led';
-          if (labelText) labelText.textContent = 'LOADING';
-          setMessage(degradedMode ? 'Reading .rbs metadata…' : 'Loading song data…');
-          break;
-        case 'ready':
-          lcdStatus.textContent = degradedMode ? 'META' : 'READY';
-          ledLabel.className = 'rb-led rb-led--online player-led';
-          if (labelText) labelText.textContent = degradedMode ? (canSketch ? 'SKETCH' : 'META') : 'ONLINE';
-          if (btnStop) btnStop.disabled = !songLoaded;
-          if (btnPlay) {
-            btnPlay.textContent = '▶';
-            btnPlay.title = degradedMode && canSketch ? 'Play sketch preview' : 'Play';
-            btnPlay.setAttribute('aria-label', 'Play');
-          }
-          updatePlayAvailability();
-          break;
-        case 'playing':
-          lcdStatus.textContent = degradedMode ? 'SKETCH' : 'PLAY';
-          ledLabel.className = 'rb-led rb-led--online player-led';
-          if (labelText) labelText.textContent = degradedMode ? 'SKETCH' : 'PLAYING';
-          if (btnPlay) {
-            btnPlay.textContent = '❚❚';
-            btnPlay.title = 'Pause';
-            btnPlay.setAttribute('aria-label', 'Pause');
-            btnPlay.disabled = false;
-          }
-          if (btnStop) btnStop.disabled = false;
-          setMessage(degradedMode ? 'Sketch preview active (metronome only)' : 'Playback active');
-          break;
-        case 'error':
-          lcdStatus.textContent = 'ERR';
-          ledLabel.className = 'rb-led rb-led--offline player-led';
-          if (labelText) labelText.textContent = 'ERROR';
-          if (degradedMode && !canSketch) {
-            setMessage('Playback unavailable in metadata-only mode — inspect file info above.');
-          } else if (degradedMode) {
-            setMessage('Sketch preview failed — reload the file and try again.');
-          } else {
-            setMessage('Playback unavailable — check console for details');
-          }
-          updatePlayAvailability();
-          break;
-      }
-    }
-
-    bridge.setStatusCallback(setStatus);
-
-    // ── Position updates ────────────────────────────────────────────
-
-    bridge.setPositionCallback((bar, step) => {
-      if (lcdBar) lcdBar.textContent = String(bar).padStart(2, '0');
-      const currentStep = ((step % 16) + 16) % 16;
-      stepDots.forEach((dot, i) => {
-        dot.classList.toggle('is-current', i === currentStep);
-        dot.classList.toggle('is-active', i <= currentStep);
-      });
-      const litSegments = Math.min(12, Math.max(1, Math.floor(((currentStep + 1) / 16) * 12)));
-      meterSegments.forEach((segment, i) => {
-        segment.classList.toggle('is-active', i < litSegments);
-      });
-    });
-
-    // ── File handling ───────────────────────────────────────────────
-
-    async function loadFile(buffer: ArrayBuffer, sourceLabel?: string) {
-      try {
-        setMessage(degradedMode ? 'Sniffing .rbs header…' : 'Parsing .rbs payload…');
-        const song = await bridge.loadRbsFile(buffer);
-        songLoaded = true;
-        if (metaTitle) metaTitle.textContent = song.title || 'Untitled';
-        if (metaAuthor) metaAuthor.textContent = song.author || 'Unknown';
-        if (metaEl) metaEl.classList.remove('is-hidden');
-        if (lcdBpm) lcdBpm.textContent = String(Math.round(song.bpm));
-        if (tempoSlider) tempoSlider.value = String(Math.round(song.bpm));
-        if (tempoValue) tempoValue.textContent = `${Math.round(song.bpm)} BPM`;
-        if (lcdBar) lcdBar.textContent = '01';
-        if (degradedMode) {
-          setMessage(
-            canSketch
-              ? `Metadata loaded — press Play for sketch preview (${sourceLabel || 'local file'})`
-              : `Metadata loaded (${sourceLabel || 'local file'}) — playback requires WASM engine`
-          );
-        } else {
-          setMessage(`Loaded ${sourceLabel || 'song file'}`);
-        }
-        updatePlayAvailability();
-      } catch (err) {
-        console.error('Failed to load .rbs:', err);
-        songLoaded = false;
-        updatePlayAvailability();
-        setMessage(`Failed to parse .rbs file${sourceLabel ? ` (${sourceLabel})` : ''}`);
-        setStatus('error');
-      }
-    }
-
-    async function loadDemoSong(url: string, label: string) {
-      setMessage(`Fetching demo: ${label}…`);
-      const res = await fetch(url);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const buf = await res.arrayBuffer();
-      await loadFile(buf, label);
-    }
-
-    window.addEventListener('rb:load-demo', async (event) => {
-      const customEvent = event as CustomEvent<{ src?: string; label?: string; bpm?: number }>;
-      const src = customEvent.detail?.src;
-      const label = customEvent.detail?.label || 'archive preview';
-      const bpm = customEvent.detail?.bpm;
-      if (!src) return;
-
-      if (demoSelect) {
-        const existing = Array.from(demoSelect.options).find((option) => option.value === src);
-        if (!existing) {
-          const opt = document.createElement('option');
-          opt.value = src;
-          opt.textContent = label;
-          if (typeof bpm === 'number') opt.dataset.bpm = String(bpm);
-          demoSelect.appendChild(opt);
-        }
-        demoSelect.value = src;
-      }
-
-      try {
-        await loadDemoSong(src, label);
-      } catch (err) {
-        console.error('Failed to load preview demo:', err);
-        setMessage('Preview fetch failed. Use local file load as fallback.');
-      }
-    });
-
-    if (demoSelect) {
-      demos.forEach((demo) => {
-        const opt = document.createElement('option');
-        opt.value = demo.src;
-        opt.textContent = demo.label;
-        opt.dataset.bpm = demo.bpm ? String(demo.bpm) : '';
-        demoSelect.appendChild(opt);
-      });
-    }
-
-    if (fileInput) {
-      fileInput.addEventListener('change', (e) => {
-        const file = (e.target as HTMLInputElement).files?.[0];
-        if (!file) return;
-        file.arrayBuffer().then((buffer) => loadFile(buffer, file.name));
-      });
-    }
-
-    // Drag & drop
-    if (dropZone) {
-      dropZone.addEventListener('dragover', (e) => {
-        e.preventDefault();
-        dropZone.classList.add('drag-over');
-      });
-      dropZone.addEventListener('dragleave', () => {
-        dropZone.classList.remove('drag-over');
-      });
-      dropZone.addEventListener('drop', (e) => {
-        e.preventDefault();
-        dropZone.classList.remove('drag-over');
-        const file = e.dataTransfer?.files[0];
-        if (file && file.name.endsWith('.rbs')) {
-          file.arrayBuffer().then((buffer) => loadFile(buffer, file.name));
-        }
-      });
-    }
-
-    // ── Transport buttons ───────────────────────────────────────────
-
-    btnPlay?.addEventListener('click', () => {
-      if (degradedMode && !canSketch) {
-        setStatus('error');
-        return;
-      }
-      if (bridge.playerStatus === 'playing') {
-        bridge.pause();
-      } else {
-        bridge.play();
-      }
-    });
-
-    btnStop?.addEventListener('click', () => {
-      bridge.stop();
-    });
-
-    btnLoad?.addEventListener('click', () => {
-      fileInput?.click();
-    });
-
-    btnDemoLoad?.addEventListener('click', async () => {
-      if (!demoSelect?.value) return;
-      try {
-        await loadDemoSong(demoSelect.value, demoSelect.selectedOptions[0]?.textContent || 'demo song');
-      } catch (err) {
-        console.error('Failed to load demo song:', err);
-        setMessage('Demo fetch failed. Use local file load as fallback.');
-      }
-    });
-
-    volumeSlider?.addEventListener('input', () => {
-      const value = Number(volumeSlider.value);
-      bridge.setVolume(value);
-      if (volumeValue) volumeValue.textContent = `${Math.round(value * 100)}%`;
-    });
-
-    tempoSlider?.addEventListener('input', () => {
-      const bpm = Number(tempoSlider.value);
-      if (tempoValue) tempoValue.textContent = `${Math.round(bpm)} BPM`;
-      const didApply = bridge.setTempoBpm(bpm);
-      if (didApply && lcdBpm) lcdBpm.textContent = String(Math.round(bpm));
-    });
-
-    async function activateDegradedMode(reason: InitFailureReason) {
-      if ('dispose' in bridge) bridge.dispose();
-      bridge = new DegradedRbsPlayer({ failureReason: reason });
-      canSketch = (bridge as DegradedRbsPlayer).canPlayAudio;
-      bridge.setStatusCallback(setStatus);
-      bridge.setPositionCallback((bar, step) => {
-        if (lcdBar) lcdBar.textContent = String(bar).padStart(2, '0');
-        const currentStep = ((step % 16) + 16) % 16;
-        stepDots.forEach((dot, i) => {
-          dot.classList.toggle('is-current', i === currentStep);
-          dot.classList.toggle('is-active', i <= currentStep);
-        });
-        const litSegments = Math.min(12, Math.max(1, Math.floor(((currentStep + 1) / 16) * 12)));
-        meterSegments.forEach((segment, i) => {
-          segment.classList.toggle('is-active', i < litSegments);
-        });
-      });
-      showDegradedFallback(reason);
-      setMessage('Initialising degraded preview…');
-      await bridge.init();
-      bridge.setVolume(Number(volumeSlider?.value ?? bridge.outputVolume));
-      if (tempoSlider) tempoSlider.disabled = false;
-      if (volumeSlider) volumeSlider.disabled = !canSketch;
-      if (tempoValue) tempoValue.textContent = `${Math.round(bridge.getTempoBpm() ?? 125)} BPM`;
-      if (!demos.length && btnDemoLoad) btnDemoLoad.disabled = false;
-      if (!demos.length) setMessage('Degraded mode — drop an .rbs file to inspect metadata.');
-    }
-
-    // ── Init ────────────────────────────────────────────────────────
-
+  document.querySelectorAll<HTMLElement>('.rbs-player').forEach((playerEl) => {
+    let demos: DemoSong[] = [];
     try {
-      setMessage('Initialising audio engine…');
-      await bridge.init();
-      setPlayerMode('wasm');
-      bridge.setVolume(Number(volumeSlider?.value ?? bridge.outputVolume));
-
-      const tempoSupported = bridge.canSetTempo();
-      if (tempoSlider) {
-        tempoSlider.disabled = !tempoSupported;
-        tempoSlider.title = tempoSupported
-          ? 'Set playback tempo (BPM)'
-          : 'Tempo control will unlock when WASM tempo API is implemented';
-      }
-      if (tempoSupported) {
-        const engineBpm = bridge.getTempoBpm();
-        if (typeof engineBpm === 'number' && engineBpm > 0) {
-          if (tempoSlider) tempoSlider.value = String(Math.round(engineBpm));
-          if (tempoValue) tempoValue.textContent = `${Math.round(engineBpm)} BPM`;
-        }
-      } else if (tempoValue) {
-        tempoValue.textContent = 'WASM TBD';
-      }
-
-      if (!demos.length && btnDemoLoad) {
-        btnDemoLoad.disabled = true;
-      }
-      if (!demos.length) setMessage('No demos configured — drop an .rbs file to preview.');
-
-      const autoplay = playerEl.dataset.autoplay === 'true';
-      const srcUrl = playerEl.dataset.src;
-
-      if (srcUrl) {
-        await loadDemoSong(srcUrl, 'initial source');
-        if (autoplay) bridge.play();
-      } else if (demos[0] && demoSelect) {
-        demoSelect.value = demos[0].src;
-      }
-    } catch (err) {
-      console.error('WASM init failed:', err);
-      const failure = classifyInitError(err);
-      await activateDegradedMode(failure.reason);
+      demos = JSON.parse(playerEl.dataset.demos || '[]') as DemoSong[];
+    } catch {
+      demos = [];
     }
-  })();
+    initPlayerUI(playerEl, {
+      demos,
+      initialSrc: playerEl.dataset.src || undefined,
+      autoplay: playerEl.dataset.autoplay === 'true',
+    });
+  });
 </script>

--- a/src/components/ui/HardwarePanel.astro
+++ b/src/components/ui/HardwarePanel.astro
@@ -7,6 +7,7 @@ interface Props extends HardwarePanelProps {}
 
 const {
   tag: Tag = 'section',
+  id,
   ariaLabel,
   ariaLabelledBy,
   title,
@@ -31,6 +32,7 @@ const animateClass = animate ? 'rb-panel--animate' : '';
 ---
 
 <Tag
+  id={id}
   class={`${isRackmount ? rackClass : 'rb-panel'} ${!isRackmount ? variantClass : ''} ${animateClass} ${className}`.trim()}
   aria-label={ariaLabel}
   aria-labelledby={ariaLabelledBy}

--- a/src/components/ui/types.ts
+++ b/src/components/ui/types.ts
@@ -105,6 +105,8 @@ export interface PanelHeaderProps {
 export interface HardwarePanelProps {
   /** Semantic HTML tag */
   tag?: 'section' | 'div' | 'article';
+  /** Element id attribute */
+  id?: string;
   /** Accessible label for the panel */
   ariaLabel?: string;
   /** ID of element that labels this panel */

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,6 +26,7 @@ const base = normalizeBase(import.meta.env.BASE_URL);
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />
     <meta name="generator" content={Astro.generator} />
+    <meta name="base-url" content={base} />
 
     <!-- Open Graph -->
     <meta property="og:title" content={title} />

--- a/src/lib/player-events.ts
+++ b/src/lib/player-events.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared player event bus for archive preview UX.
+ * Used by ModCard, archive folder pages, and the RbsPlayer component.
+ */
+
+export const PLAYER_SCROLL_TARGET = 'player-zone';
+
+export interface LoadDemoDetail {
+  src: string;
+  label?: string;
+  bpm?: number;
+  /** Request playback after load — only honoured after a user gesture on the player */
+  autoplay?: boolean;
+}
+
+export type ToastVariant = 'info' | 'success' | 'error' | 'loading';
+
+export interface ToastDetail {
+  message: string;
+  variant?: ToastVariant;
+  /** Auto-dismiss after ms (0 = manual dismiss only) */
+  duration?: number;
+}
+
+export interface PlayUrlParams {
+  src: string;
+  label?: string;
+  bpm?: number;
+  autoplay?: boolean;
+}
+
+/** Dispatch rb:load-demo to the in-page player (homepage / play page). */
+export function dispatchLoadDemo(detail: LoadDemoDetail): void {
+  window.dispatchEvent(new CustomEvent<LoadDemoDetail>('rb:load-demo', { detail }));
+}
+
+/** Scroll to the browser player section, respecting reduced-motion. */
+export function scrollToPlayer(): void {
+  const target = document.getElementById(PLAYER_SCROLL_TARGET);
+  if (!target) return;
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  target.scrollIntoView({ behavior: reducedMotion ? 'auto' : 'smooth', block: 'start' });
+  target.focus({ preventScroll: true });
+}
+
+/** Show a hardware-styled toast via the player UI. */
+export function dispatchToast(detail: ToastDetail): void {
+  window.dispatchEvent(new CustomEvent<ToastDetail>('rb:toast', { detail }));
+}
+
+/** Build a deep-link URL for the dedicated /play page. */
+export function buildPlayUrl(base: string, params: PlayUrlParams): string {
+  const url = new URL(`${base.replace(/\/$/, '')}/play`, window.location.origin);
+  url.searchParams.set('src', params.src);
+  if (params.label) url.searchParams.set('label', params.label);
+  if (typeof params.bpm === 'number') url.searchParams.set('bpm', String(params.bpm));
+  if (params.autoplay) url.searchParams.set('autoplay', '1');
+  return `${url.pathname}${url.search}`;
+}
+
+/** Parse deep-link query params from the current page URL. */
+export function parsePlayerQuery(): {
+  src: string | null;
+  label: string | null;
+  bpm: number | null;
+  autoplay: boolean;
+  playPath: string | null;
+} {
+  const params = new URLSearchParams(window.location.search);
+  const playPath = params.get('play');
+  const srcParam = params.get('src');
+  const resolvedSrc = srcParam ?? (playPath ? resolvePlayPath(playPath) : null);
+  const bpmRaw = params.get('bpm');
+  return {
+    src: resolvedSrc,
+    label: params.get('label'),
+    bpm: bpmRaw ? Number(bpmRaw) : null,
+    autoplay: params.get('autoplay') === '1',
+    playPath,
+  };
+}
+
+/** Resolve a relative archive path (from ?play=) to a full download URL. */
+export function resolvePlayPath(relativePath: string): string {
+  const encoded = relativePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `https://test.1ink.us/rb338/archive/rbs-songs/${encoded}`;
+}
+
+/** Load demo in-page when player exists; otherwise navigate to /play. */
+export function previewSong(base: string, detail: LoadDemoDetail): void {
+  const hasPlayer = Boolean(document.querySelector('.rbs-player'));
+  if (hasPlayer) {
+    dispatchLoadDemo(detail);
+    scrollToPlayer();
+    return;
+  }
+  window.location.href = buildPlayUrl(base, detail);
+}

--- a/src/pages/archive/songs/[...slug].astro
+++ b/src/pages/archive/songs/[...slug].astro
@@ -209,7 +209,7 @@ const pageTitle = `${folderName} — ${sectionName}`;
                       Size <span class="sort-indicator" aria-hidden="true">↕</span>
                     </button>
                   </th>
-                  <th scope="col" class="col-download">Download</th>
+                  <th scope="col" class="col-actions">Actions</th>
                 </tr>
               </thead>
               <tbody id="folderTableBody">
@@ -225,7 +225,19 @@ const pageTitle = `${folderName} — ${sectionName}`;
                       )}
                     </td>
                     <td class="cell-size">{song.fileSize}</td>
-                    <td class="cell-download">
+                    <td class="cell-actions">
+                      <button
+                        type="button"
+                        class="preview-btn"
+                        data-preview-src={song.url}
+                        data-preview-label={song.title}
+                        data-preview-bpm={song.bpm ?? ''}
+                        aria-label={`Preview ${song.filename} in browser`}
+                        title={`Preview ${song.filename}`}
+                      >
+                        <span class="preview-icon" aria-hidden="true">▶</span>
+                        <span class="sr-only">Play</span>
+                      </button>
                       <a
                         href={song.url}
                         target="_blank"
@@ -419,9 +431,44 @@ const pageTitle = `${folderName} — ${sectionName}`;
 
   .col-size,
   .cell-size,
-  .col-download,
-  .cell-download {
+  .col-actions,
+  .cell-actions {
     text-align: right;
+  }
+
+  .cell-actions {
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.35rem;
+  }
+
+  .preview-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    color: var(--rb-green-bright, #3dba66);
+    background: linear-gradient(180deg, #363636 0%, #282828 100%);
+    border: 1px solid var(--rb-green-dim, #1a5230);
+    border-bottom: 2px solid #111;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: all 120ms ease;
+  }
+
+  .preview-btn:hover,
+  .preview-btn:focus-visible {
+    color: var(--rb-amber, #ffb000);
+    border-color: var(--rb-amber-dim, #b37800);
+    box-shadow: 0 0 8px rgba(255, 176, 0, 0.15);
+    outline: none;
+  }
+
+  .preview-icon {
+    font-size: 0.75rem;
   }
 
   .cell-name {
@@ -654,4 +701,8 @@ const pageTitle = `${folderName} — ${sectionName}`;
       });
     });
   })();
+</script>
+
+<script>
+  import '../../../scripts/archive-preview';
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -508,7 +508,7 @@ $ _<span class="cursor-blink">█</span></code></pre>
     </div>
   </details>
 
-  <h2 class="section-zone-label" id="player-zone">Browser Preview</h2>
+  <h2 class="section-zone-label" id="player-zone" tabindex="-1">Browser Preview</h2>
 
   <!-- ╔══════════════════════════════════════════════════════════════════════╗ -->
   <!-- ║  WASM PLAYER — In-browser .rbs preview engine                       ║ -->

--- a/src/pages/play.astro
+++ b/src/pages/play.astro
@@ -1,0 +1,67 @@
+---
+// Dedicated song preview page — deep-link target for archive Play buttons
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+import RbsPlayer from '../components/RbsPlayer.astro';
+import { rbsDownloadUrl } from '../lib/archive-urls';
+
+/** Server-side query parsing for SSR title/description */
+const srcParam = Astro.url.searchParams.get('src');
+const playParam = Astro.url.searchParams.get('play');
+const labelParam = Astro.url.searchParams.get('label');
+
+const resolvedSrc = srcParam ?? (playParam ? rbsDownloadUrl(playParam) : null);
+const pageLabel = labelParam ?? (playParam ? playParam.split('/').pop()?.replace(/_/g, ' ') : null) ?? 'Song Preview';
+---
+
+<BaseLayout
+  title={pageLabel}
+  description="Preview a ReBirth RB-338 .rbs song in your browser without downloading the original software."
+>
+  <div class="play-page">
+    <div class="container">
+      <Breadcrumbs items={[
+        { label: 'Home', href: '/' },
+        { label: 'Songs', href: '/archive/songs/' },
+        { label: 'Preview' },
+      ]} />
+
+      <h1 class="play-page__title" id="player-zone" tabindex="-1">{pageLabel}</h1>
+      <p class="play-page__lead">
+        In-browser preview powered by the WASM playback engine.
+        {resolvedSrc ? ' Song loads automatically — press Play to hear audio.' : ' Select a demo or drop an .rbs file below.'}
+      </p>
+
+      <RbsPlayer
+        title="ARCHIVE PREVIEW"
+        src={resolvedSrc ?? undefined}
+        demos={[]}
+      />
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .play-page {
+    padding-block: 2rem 4rem;
+    background: #0f0f0f;
+    min-height: 60vh;
+  }
+
+  .play-page__title {
+    font-family: var(--rb-font-display, 'Courier New', monospace);
+    font-size: 1.25rem;
+    color: var(--rb-amber, #ffb000);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin: 0 0 0.5rem;
+  }
+
+  .play-page__lead {
+    font-size: 0.9rem;
+    color: #888;
+    margin: 0 0 1.5rem;
+    line-height: 1.5;
+    max-width: 60ch;
+  }
+</style>

--- a/src/scripts/archive-preview.ts
+++ b/src/scripts/archive-preview.ts
@@ -1,0 +1,21 @@
+/**
+ * Archive folder page — wire Play buttons to the in-browser preview player.
+ */
+import { previewSong } from '../lib/player-events';
+import { normalizeBase } from '../lib/url';
+
+function getBase(): string {
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="base-url"]');
+  return normalizeBase(meta?.content ?? '/rb338');
+}
+
+document.querySelectorAll<HTMLButtonElement>('.preview-btn').forEach((button) => {
+  button.addEventListener('click', () => {
+    const src = button.dataset.previewSrc;
+    if (!src) return;
+    const label = button.dataset.previewLabel ?? 'archive preview';
+    const bpmRaw = button.dataset.previewBpm;
+    const bpm = bpmRaw ? Number(bpmRaw) : undefined;
+    previewSong(getBase(), { src, label, bpm });
+  });
+});

--- a/src/wasm/js/player-ui.ts
+++ b/src/wasm/js/player-ui.ts
@@ -1,0 +1,521 @@
+/**
+ * Client-side player UI controller — extracted from RbsPlayer.astro for reuse.
+ * Wires DOM elements to WasmAudioBridge / DegradedRbsPlayer.
+ */
+
+import { WasmAudioBridge } from './WasmAudioBridge';
+import { DegradedRbsPlayer } from './DegradedRbsPlayer';
+import {
+  classifyInitError,
+  INIT_FAILURE_MESSAGES,
+  type InitFailureReason,
+} from './rbs-init-errors';
+import type { LoadDemoDetail, ToastDetail, ToastVariant } from '../../lib/player-events';
+import { parsePlayerQuery, scrollToPlayer } from '../../lib/player-events';
+import type { ParsedSong, PlayerStatus } from '../types/wasm-audio';
+
+export type PlayerBridge = WasmAudioBridge | DegradedRbsPlayer;
+
+export interface DemoSong {
+  label: string;
+  src: string;
+  bpm?: number;
+}
+
+export interface PlayerUIOptions {
+  demos?: DemoSong[];
+  initialSrc?: string;
+  autoplay?: boolean;
+}
+
+const DEVICE_LABELS: Record<string, string> = {
+  'tb303-a': '303 A',
+  'tb303-b': '303 B',
+  tr808: '808',
+  tr909: '909',
+};
+
+export function initPlayerUI(playerEl: HTMLElement, options: PlayerUIOptions = {}): void {
+  const { demos = [], initialSrc = '', autoplay = false } = options;
+
+  const dropZone = playerEl.querySelector('#rbsDropZone') as HTMLElement | null;
+  const fileInput = playerEl.querySelector('#rbsFileInput') as HTMLInputElement | null;
+  const btnPlay = playerEl.querySelector('#rbsBtnPlay') as HTMLButtonElement | null;
+  const btnStop = playerEl.querySelector('#rbsBtnStop') as HTMLButtonElement | null;
+  const btnLoad = playerEl.querySelector('#rbsBtnLoad') as HTMLButtonElement | null;
+  const metaEl = playerEl.querySelector('#rbsMeta') as HTMLElement | null;
+  const metaTitle = playerEl.querySelector('#rbsMetaTitle') as HTMLElement | null;
+  const metaAuthor = playerEl.querySelector('#rbsMetaAuthor') as HTMLElement | null;
+  const metaBpm = playerEl.querySelector('#rbsMetaBpm') as HTMLElement | null;
+  const metaDevices = playerEl.querySelector('#rbsMetaDevices') as HTMLElement | null;
+  const messageEl = playerEl.querySelector('#rbsMessage') as HTMLElement | null;
+  const demoSelect = playerEl.querySelector('#rbsDemoSelect') as HTMLSelectElement | null;
+  const btnDemoLoad = playerEl.querySelector('#rbsBtnDemoLoad') as HTMLButtonElement | null;
+  const volumeSlider = playerEl.querySelector('#rbsVolume') as HTMLInputElement | null;
+  const volumeValue = playerEl.querySelector('#rbsVolumeValue') as HTMLElement | null;
+  const tempoSlider = playerEl.querySelector('#rbsTempo') as HTMLInputElement | null;
+  const tempoValue = playerEl.querySelector('#rbsTempoValue') as HTMLElement | null;
+  const fallbackEl = playerEl.querySelector('#rbsFallback') as HTMLElement | null;
+  const fallbackHeadline = playerEl.querySelector('#rbsFallbackHeadline') as HTMLElement | null;
+  const fallbackDetail = playerEl.querySelector('#rbsFallbackDetail') as HTMLElement | null;
+  const fallbackMode = playerEl.querySelector('#rbsFallbackMode') as HTMLElement | null;
+  const toastStack = playerEl.querySelector('#rbsToastStack') as HTMLElement | null;
+  const lcdStatus = playerEl.querySelector('.player-lcd-status .lcd-value') as HTMLElement | null;
+  const lcdBpm = playerEl.querySelector('.player-lcd-bpm .lcd-value') as HTMLElement | null;
+  const lcdBar = playerEl.querySelector('.player-lcd-bar .lcd-value') as HTMLElement | null;
+  const ledLabel = playerEl.querySelector('.player-led') as HTMLElement | null;
+  const stepDots = playerEl.querySelectorAll('.step-dot');
+  const meterSegments = playerEl.querySelectorAll('.meter-segment');
+
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (reducedMotion) playerEl.classList.add('player--reduced-motion');
+
+  let bridge: PlayerBridge = new WasmAudioBridge();
+  let degradedMode = false;
+  let songLoaded = false;
+  let canSketch = false;
+  let pendingAutoplay = false;
+  let userGestureGranted = false;
+  let loadedSong: ParsedSong | null = null;
+  const toastTimers = new Map<HTMLElement, number>();
+
+  function setMessage(message: string) {
+    if (messageEl) messageEl.textContent = message;
+  }
+
+  function setPlayerMode(mode: 'wasm' | 'degraded-sketch' | 'degraded-metadata') {
+    playerEl.dataset.playerMode = mode;
+  }
+
+  function showToast(message: string, variant: ToastVariant = 'info', duration = 4000) {
+    if (!toastStack) {
+      setMessage(message);
+      return;
+    }
+    const toast = document.createElement('div');
+    toast.className = `player-toast player-toast--${variant}`;
+    toast.setAttribute('role', variant === 'error' ? 'alert' : 'status');
+    toast.textContent = message;
+    toastStack.appendChild(toast);
+
+    if (duration > 0) {
+      const timer = window.setTimeout(() => dismissToast(toast), duration);
+      toastTimers.set(toast, timer);
+    }
+  }
+
+  function dismissToast(toast: HTMLElement) {
+    const timer = toastTimers.get(toast);
+    if (timer) window.clearTimeout(timer);
+    toastTimers.delete(toast);
+    toast.remove();
+  }
+
+  window.addEventListener('rb:toast', (event) => {
+    const { message, variant = 'info', duration = 4000 } = (event as CustomEvent<ToastDetail>).detail;
+    showToast(message, variant, duration ?? 4000);
+  });
+
+  function showDegradedFallback(reason: InitFailureReason) {
+    degradedMode = true;
+    fallbackEl?.classList.remove('is-hidden');
+    if (fallbackEl) fallbackEl.dataset.failureReason = reason;
+    if (fallbackDetail) fallbackDetail.textContent = INIT_FAILURE_MESSAGES[reason];
+    if (fallbackHeadline) {
+      fallbackHeadline.textContent = reason === 'wasm-unavailable'
+        ? 'WASM engine not built'
+        : 'Full playback unavailable';
+    }
+    if (fallbackMode) {
+      fallbackMode.textContent = canSketch
+        ? 'Degraded mode: metadata + metronome sketch preview (not full ReBirth synthesis).'
+        : 'Degraded mode: metadata only — load a file to inspect title and author.';
+    }
+    setPlayerMode(canSketch ? 'degraded-sketch' : 'degraded-metadata');
+  }
+
+  function updatePlayAvailability() {
+    if (!btnPlay) return;
+    if (!degradedMode) {
+      btnPlay.disabled = !songLoaded && bridge.playerStatus !== 'ready' && bridge.playerStatus !== 'playing';
+      return;
+    }
+    btnPlay.disabled = !songLoaded || !canSketch;
+    btnPlay.title = canSketch
+      ? (songLoaded ? 'Play sketch preview (metronome)' : 'Load a song first')
+      : 'Sketch preview unavailable — metadata only';
+  }
+
+  function markUserGesture() {
+    userGestureGranted = true;
+    if (pendingAutoplay && songLoaded && bridge.playerStatus === 'ready') {
+      pendingAutoplay = false;
+      bridge.play();
+    }
+  }
+
+  function setStatus(status: PlayerStatus) {
+    if (!lcdStatus || !ledLabel) return;
+
+    const labelText = ledLabel.querySelector('.rb-led__label');
+
+    switch (status) {
+      case 'idle':
+        lcdStatus.textContent = 'IDLE';
+        ledLabel.className = 'rb-led rb-led--pending player-led';
+        if (labelText) labelText.textContent = degradedMode ? 'DEGRADED' : 'PENDING';
+        if (btnPlay) {
+          btnPlay.textContent = '▶';
+          btnPlay.title = 'Play';
+          btnPlay.setAttribute('aria-label', 'Play');
+        }
+        break;
+      case 'loading':
+        lcdStatus.textContent = 'LOAD…';
+        ledLabel.className = 'rb-led rb-led--pending player-led';
+        if (labelText) labelText.textContent = 'LOADING';
+        setMessage(degradedMode ? 'Reading .rbs metadata…' : 'Loading song data…');
+        showToast(degradedMode ? 'Reading .rbs metadata…' : 'Loading song data…', 'loading', 0);
+        break;
+      case 'ready':
+        lcdStatus.textContent = degradedMode ? 'META' : 'READY';
+        ledLabel.className = 'rb-led rb-led--online player-led';
+        if (labelText) labelText.textContent = degradedMode ? (canSketch ? 'SKETCH' : 'META') : 'ONLINE';
+        btnStop && (btnStop.disabled = !songLoaded);
+        if (btnPlay) {
+          btnPlay.textContent = '▶';
+          btnPlay.title = degradedMode && canSketch ? 'Play sketch preview' : 'Play';
+          btnPlay.setAttribute('aria-label', 'Play');
+        }
+        updatePlayAvailability();
+        break;
+      case 'playing':
+        lcdStatus.textContent = degradedMode ? 'SKETCH' : 'PLAY';
+        ledLabel.className = 'rb-led rb-led--online player-led';
+        if (labelText) labelText.textContent = degradedMode ? 'SKETCH' : 'PLAYING';
+        if (btnPlay) {
+          btnPlay.textContent = '❚❚';
+          btnPlay.title = 'Pause';
+          btnPlay.setAttribute('aria-label', 'Pause');
+          btnPlay.disabled = false;
+        }
+        if (btnStop) btnStop.disabled = false;
+        setMessage(degradedMode ? 'Sketch preview active (metronome only)' : 'Playback active');
+        break;
+      case 'error':
+        lcdStatus.textContent = 'ERR';
+        ledLabel.className = 'rb-led rb-led--offline player-led';
+        if (labelText) labelText.textContent = 'ERROR';
+        if (degradedMode && !canSketch) {
+          setMessage('Playback unavailable in metadata-only mode — inspect file info above.');
+        } else if (degradedMode) {
+          setMessage('Sketch preview failed — reload the file and try again.');
+        } else {
+          setMessage('Playback unavailable — check console for details');
+        }
+        updatePlayAvailability();
+        break;
+    }
+  }
+
+  function updatePositionVisuals(bar: number, step: number) {
+    if (lcdBar) lcdBar.textContent = String(bar).padStart(2, '0');
+    const currentStep = ((step % 16) + 16) % 16;
+    stepDots.forEach((dot, i) => {
+      dot.classList.toggle('is-current', i === currentStep);
+      if (bridge.playerStatus === 'playing' || bridge.playerStatus === 'ready') {
+        dot.classList.toggle('is-active', i <= currentStep);
+      }
+    });
+    const litSegments = Math.min(12, Math.max(1, Math.floor(((currentStep + 1) / 16) * 12)));
+    meterSegments.forEach((segment, i) => {
+      segment.classList.toggle('is-active', i < litSegments);
+    });
+  }
+
+  function applyPatternPreview(song: ParsedSong) {
+    const patternSteps = new Set<number>();
+    for (const pattern of song.patterns) {
+      pattern.steps.forEach((stepData, index) => {
+        if (stepData.active) patternSteps.add(index);
+      });
+    }
+    stepDots.forEach((dot, i) => {
+      dot.classList.toggle('is-pattern', patternSteps.has(i));
+      if (bridge.playerStatus !== 'playing') {
+        dot.classList.toggle('is-active', patternSteps.has(i));
+      }
+    });
+  }
+
+  function renderMetadataPanel(song: ParsedSong) {
+    if (metaTitle) metaTitle.textContent = song.title || 'Untitled';
+    if (metaAuthor) metaAuthor.textContent = song.author || 'Unknown';
+    if (metaBpm) metaBpm.textContent = `${Math.round(song.bpm)} BPM`;
+    metaEl?.classList.remove('is-hidden');
+
+    if (metaDevices) {
+      metaDevices.innerHTML = '';
+      const activeDevices = song.devices.length > 0
+        ? song.devices
+        : [{ deviceId: 'tb303-a' as const, knobs: {}, muted: false }];
+
+      for (const device of activeDevices) {
+        const chip = document.createElement('span');
+        chip.className = `meta-device${device.muted ? ' meta-device--muted' : ''}`;
+        const label = DEVICE_LABELS[device.deviceId] ?? device.deviceId;
+        const patternCount = song.patterns.filter((p) => p.deviceId === device.deviceId).length;
+        chip.innerHTML = `<span class="meta-device__led" aria-hidden="true"></span><span class="meta-device__label">${label}</span><span class="meta-device__count">${patternCount}P</span>`;
+        chip.title = `${label}${device.muted ? ' (muted)' : ''} — ${patternCount} patterns`;
+        metaDevices.appendChild(chip);
+      }
+    }
+
+    applyPatternPreview(song);
+  }
+
+  bridge.setStatusCallback(setStatus);
+  bridge.setPositionCallback(updatePositionVisuals);
+
+  async function loadFile(buffer: ArrayBuffer, sourceLabel?: string) {
+    try {
+      setMessage(degradedMode ? 'Sniffing .rbs header…' : 'Parsing .rbs payload…');
+      const song = await bridge.loadRbsFile(buffer);
+      songLoaded = true;
+      loadedSong = song;
+      renderMetadataPanel(song);
+      if (lcdBpm) lcdBpm.textContent = String(Math.round(song.bpm));
+      if (tempoSlider) tempoSlider.value = String(Math.round(song.bpm));
+      if (tempoValue) tempoValue.textContent = `${Math.round(song.bpm)} BPM`;
+      if (lcdBar) lcdBar.textContent = '01';
+      toastStack?.querySelectorAll('.player-toast--loading').forEach((t) => dismissToast(t as HTMLElement));
+      const msg = degradedMode
+        ? (canSketch
+          ? `Loaded — press Play for sketch preview (${sourceLabel || 'local file'})`
+          : `Metadata loaded (${sourceLabel || 'local file'})`)
+        : `Loaded ${sourceLabel || 'song file'} — press Play to hear preview`;
+      setMessage(msg);
+      showToast(msg, 'success');
+      updatePlayAvailability();
+    } catch (err) {
+      console.error('Failed to load .rbs:', err);
+      songLoaded = false;
+      loadedSong = null;
+      updatePlayAvailability();
+      const errMsg = `Failed to parse .rbs${sourceLabel ? ` (${sourceLabel})` : ''}`;
+      setMessage(errMsg);
+      showToast(errMsg, 'error');
+      setStatus('error');
+    }
+  }
+
+  async function loadDemoSong(url: string, label: string, requestAutoplay = false) {
+    showToast(`Fetching: ${label}…`, 'loading', 0);
+    setMessage(`Fetching demo: ${label}…`);
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const buf = await res.arrayBuffer();
+      await loadFile(buf, label);
+      if (requestAutoplay) {
+        if (userGestureGranted) {
+          bridge.play();
+        } else {
+          pendingAutoplay = true;
+        }
+      }
+    } catch (err) {
+      console.error('Failed to load preview demo:', err);
+      toastStack?.querySelectorAll('.player-toast--loading').forEach((t) => dismissToast(t as HTMLElement));
+      const isCors = err instanceof TypeError;
+      const errMsg = isCors
+        ? 'Preview blocked (CORS) — download the file or use a local copy'
+        : 'Preview fetch failed — try local file load';
+      setMessage(errMsg);
+      showToast(errMsg, 'error');
+      setStatus('error');
+      throw err;
+    }
+  }
+
+  window.addEventListener('rb:load-demo', async (event) => {
+    const { src, label = 'archive preview', bpm, autoplay: requestAutoplay } =
+      (event as CustomEvent<LoadDemoDetail>).detail;
+    if (!src) return;
+
+    if (demoSelect) {
+      const existing = Array.from(demoSelect.options).find((option) => option.value === src);
+      if (!existing) {
+        const opt = document.createElement('option');
+        opt.value = src;
+        opt.textContent = label;
+        if (typeof bpm === 'number') opt.dataset.bpm = String(bpm);
+        demoSelect.appendChild(opt);
+      }
+      demoSelect.value = src;
+    }
+
+    try {
+      await loadDemoSong(src, label, requestAutoplay);
+    } catch {
+      /* errors handled in loadDemoSong */
+    }
+  });
+
+  if (demoSelect) {
+    demos.forEach((demo) => {
+      const opt = document.createElement('option');
+      opt.value = demo.src;
+      opt.textContent = demo.label;
+      if (demo.bpm) opt.dataset.bpm = String(demo.bpm);
+      demoSelect.appendChild(opt);
+    });
+  }
+
+  fileInput?.addEventListener('change', (e) => {
+    markUserGesture();
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    file.arrayBuffer().then((buffer) => loadFile(buffer, file.name));
+  });
+
+  if (dropZone) {
+    dropZone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      dropZone.classList.add('drag-over');
+    });
+    dropZone.addEventListener('dragleave', () => {
+      dropZone.classList.remove('drag-over');
+    });
+    dropZone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      markUserGesture();
+      dropZone.classList.remove('drag-over');
+      const file = e.dataTransfer?.files[0];
+      if (file && file.name.endsWith('.rbs')) {
+        file.arrayBuffer().then((buffer) => loadFile(buffer, file.name));
+      }
+    });
+  }
+
+  btnPlay?.addEventListener('click', () => {
+    markUserGesture();
+    if (degradedMode && !canSketch) {
+      setStatus('error');
+      return;
+    }
+    if (bridge.playerStatus === 'playing') {
+      bridge.pause();
+    } else {
+      bridge.play();
+    }
+  });
+
+  btnStop?.addEventListener('click', () => {
+    markUserGesture();
+    bridge.stop();
+    if (loadedSong) applyPatternPreview(loadedSong);
+  });
+
+  btnLoad?.addEventListener('click', () => {
+    markUserGesture();
+    fileInput?.click();
+  });
+
+  btnDemoLoad?.addEventListener('click', async () => {
+    markUserGesture();
+    if (!demoSelect?.value) return;
+    try {
+      await loadDemoSong(demoSelect.value, demoSelect.selectedOptions[0]?.textContent || 'demo song');
+    } catch {
+      /* handled */
+    }
+  });
+
+  volumeSlider?.addEventListener('input', () => {
+    const value = Number(volumeSlider.value);
+    bridge.setVolume(value);
+    if (volumeValue) volumeValue.textContent = `${Math.round(value * 100)}%`;
+  });
+
+  tempoSlider?.addEventListener('input', () => {
+    const bpm = Number(tempoSlider.value);
+    if (tempoValue) tempoValue.textContent = `${Math.round(bpm)} BPM`;
+    const didApply = bridge.setTempoBpm(bpm);
+    if (didApply && lcdBpm) lcdBpm.textContent = String(Math.round(bpm));
+  });
+
+  async function activateDegradedMode(reason: InitFailureReason) {
+    if ('dispose' in bridge) bridge.dispose();
+    bridge = new DegradedRbsPlayer({ failureReason: reason });
+    canSketch = bridge.canPlayAudio;
+    bridge.setStatusCallback(setStatus);
+    bridge.setPositionCallback(updatePositionVisuals);
+    showDegradedFallback(reason);
+    setMessage('Initialising degraded preview…');
+    await bridge.init();
+    bridge.setVolume(Number(volumeSlider?.value ?? bridge.outputVolume));
+    if (tempoSlider) tempoSlider.disabled = false;
+    if (volumeSlider) volumeSlider.disabled = !canSketch;
+    if (tempoValue) tempoValue.textContent = `${Math.round(bridge.getTempoBpm() ?? 125)} BPM`;
+    if (!demos.length && btnDemoLoad) btnDemoLoad.disabled = false;
+    if (!demos.length) setMessage('Degraded mode — drop an .rbs file to inspect metadata.');
+  }
+
+  async function bootstrap() {
+    try {
+      setMessage('Initialising audio engine…');
+      await bridge.init();
+      setPlayerMode('wasm');
+      bridge.setVolume(Number(volumeSlider?.value ?? bridge.outputVolume));
+
+      const tempoSupported = bridge.canSetTempo();
+      if (tempoSlider) {
+        tempoSlider.disabled = !tempoSupported;
+        tempoSlider.title = tempoSupported
+          ? 'Set playback tempo (BPM)'
+          : 'Tempo control will unlock when WASM tempo API is implemented';
+      }
+      if (tempoSupported) {
+        const engineBpm = bridge.getTempoBpm();
+        if (typeof engineBpm === 'number' && engineBpm > 0) {
+          if (tempoSlider) tempoSlider.value = String(Math.round(engineBpm));
+          if (tempoValue) tempoValue.textContent = `${Math.round(engineBpm)} BPM`;
+        }
+      } else if (tempoValue) {
+        tempoValue.textContent = 'WASM TBD';
+      }
+
+      if (!demos.length && btnDemoLoad) btnDemoLoad.disabled = true;
+      if (!demos.length) setMessage('No demos configured — drop an .rbs file to preview.');
+
+      const query = parsePlayerQuery();
+      const srcUrl = initialSrc || query.src;
+      const shouldAutoplay = autoplay || query.autoplay;
+
+      if (srcUrl) {
+        const label = query.label || 'linked preview';
+        await loadDemoSong(srcUrl, label, shouldAutoplay);
+        if (query.src || query.playPath || initialSrc) scrollToPlayer();
+      } else if (demos[0] && demoSelect) {
+        demoSelect.value = demos[0].src;
+      }
+    } catch (err) {
+      console.error('WASM init failed:', err);
+      const failure = classifyInitError(err);
+      await activateDegradedMode(failure.reason);
+
+      const query = parsePlayerQuery();
+      const srcUrl = initialSrc || query.src;
+      if (srcUrl) {
+        try {
+          await loadDemoSong(srcUrl, query.label || 'linked preview', autoplay || query.autoplay);
+        } catch {
+          /* handled */
+        }
+      }
+    }
+  }
+
+  void bootstrap();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the "living museum" preview UX so users can hear archive songs without downloading ReBirth.

### Archive browsing
- **Play (▶) button** on every `.rbs` row in `/archive/songs/[...slug]` — navigates to `/play?src=…` with song metadata
- Download button retained alongside Play in a new Actions column

### Homepage & featured cards
- **Preview** buttons dispatch `rb:load-demo` and scroll to `#player-zone` (fixed broken `#wasm-heading` target)
- Homepage supports deep-links: `?src=<url>` or `?play=<archive-relative-path>`

### Dedicated play page
- New route **`/play`** — deep-link target for archive Play buttons and shareable URLs
- Auto-loads song from query params; user must press Play to hear audio (autoplay policy)

### Player enhancements
- Extracted client logic to **`src/wasm/js/player-ui.ts`** for reuse
- Shared event bus in **`src/lib/player-events.ts`** (`rb:load-demo`, `rb:toast`, `scrollToPlayer`, `buildPlayUrl`)
- **Metadata panel**: title, author, BPM, device chips (303 A/B, 808, 909) with pattern counts
- **Pattern LED strip**: highlights active steps from parsed patterns when song loads
- **Hardware-styled toasts** for loading, success, and error states
- **`prefers-reduced-motion`**: disables smooth scroll and toast/step animations
- **Autoplay gated** behind user gesture — deep-links load the file but won't auto-play until Play is clicked

### Notes
- Remote archive files require CORS on `test.1ink.us`; CORS failures show a clear toast
- Full WASM synthesis still requires `npm run wasm:build`; degraded mode (metadata + metronome sketch) works without WASM binaries

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — 74 pages including `/play`
- [ ] Manual: archive folder → Play → `/play` loads song metadata
- [ ] Manual: homepage Preview → scrolls to player, loads demo
- [ ] Manual: `/?play=Artists/Cavey/3_acid.rbs` auto-loads on homepage
- [ ] Manual: verify Play requires click (no autoplay on page load)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f4c4867-5ceb-4d78-a047-7dcfc595c8e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f4c4867-5ceb-4d78-a047-7dcfc595c8e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

